### PR TITLE
Add GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,70 @@
+# GitHub issue form. For more information see:
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Report something is not working properly 🐛
+description:
+  Use this if there is something that is not working properly.  If you are not
+  sure or you need help making something work, please ask a question instead.
+labels: priority:❓, type:bug
+body:
+  - type: markdown
+    attributes:
+      value:
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Please tell us what happened that shouldn't have.
+      placeholder: What happened that shouldn't have.
+    validations:
+      required: true
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What did you expect instead?
+      description: Please tell us what did you expect to happen.
+      placeholder: What did you expect to happen.
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Affected version(s)
+      description:
+        Which version(s) have you tried and found this issue in? (if you see
+        this issue **not** happening on any version, please let us know in the
+        "Extra information").
+      multiple: true
+      options:
+        - I don't know (version:❓)
+        - An older version (version:older)
+        - v0.10.x (version:0.10.x)
+    validations:
+      required: true
+  - type: dropdown
+    id: part
+    attributes:
+      label: Affected part(s)
+      description:
+        Which parts of the repo are affected by this issue? Select all that
+        apply.
+      multiple: true
+      options:
+        - I don't know (part:❓)
+        - Documentation (part:docs)
+        - Unit, integration and performance tests (part:tests)
+        - Build script, CI, dependencies, etc. (part:tooling)
+        - Protocol buffer definition (part:protobuf)
+        - Python bindings (part:python)
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Extra information
+      description:
+        Please write here any extra information you think it might be relevant,
+        e.g., if this didn't happened before, or if you suspect where the
+        problem might be.
+      placeholder: Any extra information you think it might be relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+# GitHub issue template chooser. For more information see:
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question ❓
+    url: https://github.com/frequenz-floss/frequenz-api-microgrid-proto/discussions/new?category=support
+    about: Use this if you are not sure how to do something, have installation problems, etc.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,58 @@
+# GitHub issue form. For more information see:
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+
+name: Request a feature or enhancement ✨
+description: Use this if something is missing or could be done better or easier.
+labels: part:❓, priority:❓, type:enhancement
+body:
+  - type: markdown
+    attributes:
+      value:
+        Thanks for taking the time to fill out this feature or enhancement
+        request!
+  - type: textarea
+    id: whats-needed
+    attributes:
+      label: What's needed?
+      description:
+        Please tell us what's missing or what could be done better or easier.
+      placeholder: What's missing or what could be done better or easier.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description:
+        Please tell us how do you think the needs above can be fulfilled. Only
+        fill this field if it wasn't described above.
+      placeholder:
+        How do you think the needs above can be fulfilled. Only fill this field
+        if it wasn't described above.
+  - type: textarea
+    id: use-cases
+    attributes:
+      label: Use cases
+      description:
+        Please tell us about the main use cases you see for this new feature or
+        enhancement to help us understand more.
+      placeholder:
+        The main use cases you see for this new feature or enhancement to help
+        us understand more.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives and workarounds
+      description:
+        Please tell us if you tried any alternatives or workarounds for those
+        use cases and how (un)useful they are.
+      placeholder:
+        Any alternatives or workarounds for those use cases and how (un)useful
+        they are.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description:
+        Please add any addition information here, screenshots, diagrams, etc.
+      placeholder: Any addition information here, screenshots, diagrams, etc.


### PR DESCRIPTION
Add a form for reporting bugs and requesting new features. Also configures the new issue screen to show both templates plus a quick access to ask questions in the Discussions forum.

I'm not so sure about the `version:xxx` labels (and the form entry). I think for this repo it might be overkill but eventually for other repos it might be useful, specially when bug reports come from external users, is a good way to make users think about which version are they using (and thus check if it is the latest one).

If this becomes too annoying (as with all the latest PRs), we can change it.

For more info on GitHub issue forms: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
