### PR TITLE
ci: Create GitHub Release automatically

### DIFF
--- a/.github/RELEASE_NOTES.template.md
+++ b/.github/RELEASE_NOTES.template.md
@@ -1,0 +1,17 @@
+# Frequenz Migrogrid API Release Notes
+
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including if there are any depractions and what they should be replaced with --> 
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,9 +84,9 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-  publish-to-pypi:
+  create-github-release:
     needs: ["protolint", "tests", "build-dist"]
-    # Publish only on tags creation
+    # Create a release only on tags creation
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-20.04
     steps:
@@ -94,10 +94,52 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: frequenz-api-microgrid-dist
+          path: dist
+
+      - name: Download RELEASE_NOTES.md
+        run: |
+          set -ux
+          gh api \
+              -X GET \
+              -f ref=$REF \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPOSITORY/contents/RELEASE_NOTES.md" \
+            > RELEASE_NOTES.md
+        env:
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        run: |
+          set -ux
+          extra_opts=
+          if echo "$REF_NAME" | grep -- -; then extra_opts=" --prerelease"; fi
+          gh release create \
+            -R "$REPOSITORY" \
+            --discussion-category announcements \
+            --notes-file RELEASE_NOTES.md \
+            --generate-notes \
+            $extra_opts \
+            $REF_NAME \
+            dist/*
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-to-pypi:
+    needs: ["create-github-release"]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download dist files
+        uses: actions/download-artifact@v3
+        with:
+          name: frequenz-api-microgrid-dist
+          path: dist
 
       - name: Publish the Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: ./
           skip_existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Changelog
-
-## Unreleased
-
-### Added
-
-### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+Contributing to Frequenz Microgrid API
+======================================
+
+
+Build
+=====
+
+You can use `build` to simply build the source and binary distribution:
+
+```sh
+python -m pip install build
+python -m build
+```
+
+Local development
+=================
+
+You need to make sure you have the `git submodules` updated:
+
+```sh
+git submodule update --init
+```
+
+If you want to manually compile the proto files you need to install the build
+dependencies manually (sadly it seems like there is no way to install build
+dependencies from the `pyproject.toml` file with a simple command):
+
+```sh
+python -m pip install grpcio-tools mypy-protobuf setuptools setuptools_scm[toml] wheel
+```
+
+Then you can compile the proto files by running:
+
+```sh
+python setup.py compile_proto
+```
+
+If you have any issues with these dependencies, please check the
+`pyproject.toml` file and try installing the exact supported versions instead.
+
+
+Releasing
+=========
+
+These are the steps to create a new release:
+
+1. Get the latest head you want to create a release from.
+
+1. Update the `RELEASE_NOTES.md` file if it is not complete, up to date, and
+   clean from template comments (`<!-- ... ->`) and empty sections. Submit
+   a pull request if an update is needed, wait until it is merged, and update
+   the latest head you want to create a release from to get the new merged pull
+   request.
+
+3. Create a new signed tag using the release notes and
+   a [semver](https://semver.org/) compatible version number with a `v` prefix,
+   for example:
+
+   ```sh
+   git tag -s -F RELEASE_NOTES.md v0.0.1
+   ```
+
+4. Push the new tag.
+
+5. A GitHub action will test the tag and if all goes well it will create
+   a [GitHub
+   Release](https://github.com/frequenz-floss/frequenz-api-microgrid/releases),
+   create a new
+   [announcement](https://github.com/frequenz-floss/frequenz-api-microgrid/discussions/categories/announcements)
+   about the release, and upload a new package to
+   [PyPI](https://pypi.org/project/frequenz-api-microgrid/) automatically.
+
+6. Once this is done, reset the `RELEASE_NOTES.md` with the template:
+
+   ```sh
+   cp .github/RELEASE_NOTES.template.md RELEASE_NOTES.md
+   ```
+
+   Commit the new release notes and create a PR (this step should be automated
+   eventually too).
+
+7. Celebrate!

--- a/README.md
+++ b/README.md
@@ -8,38 +8,9 @@ This repository provides the core gRPC and protobuf spec together with
 support for generating dedicated API packages for various languages.
 
 
-Build
-=====
+Contributing
+============
 
-You can use `build` to simply build the source and binary distribution:
-
-```sh
-python -m pip install build
-python -m build
-```
-
-Local development
-=================
-
-You need to make sure you have the `git submodules` updated:
-
-```sh
-git submodule update --init
-```
-
-If you want to manually compile the proto files you need to install the build
-dependencies manually (sadly it seems like there is no way to install build
-dependencies from the `pyproject.toml` file with a simple command):
-
-```sh
-python -m pip install grpcio-tools mypy-protobuf setuptools setuptools_scm[toml] wheel
-```
-
-Then you can compile the proto files by running:
-
-```sh
-python setup.py compile_proto
-```
-
-If you have any issues with these dependencies, please check the
-`pyproject.toml` file and try installing the exact supported versions instead.
+If you want to know how to build this project and contribute to it, please
+check out the [Contributing
+Guide](https://github.com/frequenz-floss/frequenz-api-microgrid/CONTRIBUTING.md).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,12 @@
+# Frequenz Migrogrid API Release Notes
+
+## Summary
+
+This is the first public open source release based on the internal version v0.10.0. There are no breaking changes in this release, only changes to the
+project structure, metadata, and automation. Packages are also now uploaded to PyPI as [`frequenz-api-microgrid`](https://pypi.org/project/frequenz-api-microgrid/), so this project now can be installed normally via `pip`:
+
+```sh
+python -m pip install frequenz-api-microgrid
+```
+
+The GitHub issues were also improved, adding templates for [reporting issues](https://github.com/frequenz-floss/frequenz-api-microgrid/issues/new?assignees=&labels=priority%3A%E2%9D%93%2C+type%3Abug&template=bug.yml) and [requesting features](https://github.com/frequenz-floss/frequenz-api-microgrid/issues/new?assignees=&labels=part%3A%E2%9D%93%2C+priority%3A%E2%9D%93%2C+type%3Aenhancement&template=feature.yml). Users are also pointed to the [Discussion forums](https://github.com/frequenz-floss/frequenz-api-microgrid/issues/new/choose) when trying to open an issue if they have questions instead. Also many labels are assigned automatically on issue and pull request creation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ name ="Frequenz Energy-as-a-Service GmbH"
 email = "floss@frequenz.com"
 
 [project.urls]
-Changelog = "https://github.com/frequenz-floss/frequenz-api-microgrid/blob/master/CHANGELOG.md"
+Changelog = "https://github.com/frequenz-floss/frequenz-api-microgrid/releases"
 Repository = "https://github.com/frequenz-floss/frequenz-api-microgrid"
 Issues = "https://github.com/frequenz-floss/frequenz-api-microgrid/issues"
 Support = "https://github.com/frequenz-floss/frequenz-api-microgrid/discussions/categories/support"


### PR DESCRIPTION
Add a GitHub job to create the GitHub Release automatically when a version is tagged. Also use the GitHub feature to create the `CHANGELOG` automatically. For this the `CHANGELOG.md` is removed in favor of a `RELEASE_NOTES.md` files that should only contain an explanation on the release main changes.

Also add the release notes for the current release.