### PR TITLE
Add write permissions to the release job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,11 @@ jobs:
     needs: ["protolint", "tests", "build-dist"]
     # Create a release only on tags creation
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    permissions:
+      # We need write permissions on contents to create GitHub releases and on
+      # discussions to create the release announcement in the discussion forums
+      contents: write
+      discussions: write
     runs-on: ubuntu-20.04
     steps:
       - name: Download dist files


### PR DESCRIPTION
The job to create the GitHub release needs write permissions on the contents to be able to create the GitHub release.
