### PR TITLE
Remove unnecessary setuptools.find configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,5 @@ Support = "https://github.com/frequenz-floss/frequenz-api-microgrid/discussions/
 [tool.setuptools.package-data]
 "frequenz.api.microgrid" = [ "py.typed", "*.pyi" ]
 
-[tools.setuptools.packages.find_namespace]
-where = "py"
-
 [tool.setuptools_scm]
 version_scheme = "post-release"


### PR DESCRIPTION
When configuring through pyproject.toml, setuptools will automatically discover packages using native namespaces in the package-dir.
