### PR TITLE
ci: Test also Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Fetch sources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "grpcio-tools >= 1.47.0, < 2",
     "mypy-protobuf >= 3.0.0, < 4",
-    "setuptools >= 63.1.0, < 64",
+    "setuptools >= 65.4.1, < 66",
     "setuptools_scm[toml] >= 7.0.5, < 8",
     "wheel"
 ]


### PR DESCRIPTION
We are very close to the release of Python 3.11 so it's a good idea to start testing aginst it too.
