### PR TITLE
Add enum variants for setting bounds on currents

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,13 @@
   microgrid metadata. The returned value is an instance of the message
   `Metadata`.
 
+* [Added enum variants for setting bounds on currents](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/33).
+  This will allow clients to set bounds on a components
+  1. DC electrical current,
+  2. total AC electrical current,
+  3. per-phase AC electrical currents.
+
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -342,6 +342,10 @@ message SetBoundsParam {
   enum TargetMetric {
     TARGET_METRIC_UNSPECIFIED = 0;
     TARGET_METRIC_POWER_ACTIVE = 1;
+    TARGET_METRIC_CURRENT = 2;
+    TARGET_METRIC_CURRENT_PHASE_1 = 3;
+    TARGET_METRIC_CURRENT_PHASE_2 = 4;
+    TARGET_METRIC_CURRENT_PHASE_3 = 5;
   }
 
   // The ID of the target component.


### PR DESCRIPTION
This will allow clients to set bounds on a components
a. DC electrical current,
b. total AC electrical current,
c. per-phase AC electrical currents.