### PR TITLE
Add RPC to set active power using a signed integer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,10 @@
   2. total AC electrical current,
   3. per-phase AC electrical currents.
 
+* [Add RPC to set active power using a signed integer](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/35).
+  While reading power values, the passive sign convention is followed
+  (-ve for production, and +ve for consumption). This new method allows setting
+  active power values in the same convention, making the API more consistent.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -107,7 +107,10 @@ service Microgrid {
   //
   // * Inverter: Sends the charge command to the inverter, making it consume AC
   //  power.
+  //
+  // Deprecated: use `SetPowerActive` instead.
   rpc Charge(PowerLevelParam) returns (google.protobuf.Empty) {
+    option deprecated = true;
     option (google.api.http) = {
       get : "/v1/components/{component_id}/charge/{power_w}"
     };
@@ -126,9 +129,31 @@ service Microgrid {
   //
   // * Inverter: Sends the discharge command to the inverter, making it deliver
   //  AC power.
+  //
+  // Deprecated: use `SetPowerActive` instead.
   rpc Discharge(PowerLevelParam) returns (google.protobuf.Empty) {
+    option deprecated = true;
     option (google.api.http) = {
       get : "/v1/components/{component_id}/discharge/{power_w}"
+    };
+  }
+
+  // Sets the power output of a component with a given ID, provided the
+  // component supports it.
+  //
+  // Note that the target component may have a resolution of more than 1 W.
+  // E.g., an inverter may have a resolution of 88 W.
+  // In such cases, the magnitude of power will be floored to the nearest
+  // multiple of the resolution.
+  //
+  // Performs the following sequence actions for the following component
+  // categories:
+  //
+  // * Inverter: Sends the discharge command to the inverter, making it deliver
+  //  AC power.
+  rpc SetPowerActive(SetPowerActiveParam) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      get : "/v1/components/{component_id}/setPowerActive/{power}"
     };
   }
 
@@ -334,6 +359,17 @@ message PowerLevelParam {
   // of the power level is controlled by the implementations of the `Charge`
   // and `Discharge` RPC methods.
   uint64 power_w = 2;
+}
+
+// Parameters for setting the active power of an appropriate component using the
+// `SetPowerActive` RPC.
+message SetPowerActiveParam {
+  // The ID of the component to set the output active power of.
+  uint64 component_id = 1;
+
+  // The output active power level, in watts.
+  // -ve values are for discharging, and +ve values are for charging.
+  int32 power = 2;
 }
 
 // Parameters for setting bounds of a given metric of a given component.

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -369,7 +369,7 @@ message SetPowerActiveParam {
 
   // The output active power level, in watts.
   // -ve values are for discharging, and +ve values are for charging.
-  int32 power = 2;
+  float power = 2;
 }
 
 // Parameters for setting bounds of a given metric of a given component.


### PR DESCRIPTION
While reading power values, the passive sign convention is followed (-ve for production, and +ve for consumption). This new method allows setting active power values in the same convention, making the API more consistent.