### PR TITLE
Introduce minimum bounds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -67,6 +67,24 @@
   `----` values here are disallowed and wil be rejected, and
   `====` values here are allowed and will be accepted.
 
+  Two new simple RPCs for setting exclusion and inclusion bounds have been
+  added:
+  * `AddExclusionBounds`: adds a pair of exclusion bounds for a given component
+    and metric, and returns the UTC timestamp until when it will stay in effect.
+  * `AddInclusionBounds`: adds a pair of inclusion bounds for a given component
+    and metric, and returns the UTC timestamp until when it will stay in effect.
+
+  Exclusion bounds are a useful tool for enhancing the performance of a system.
+  They can be used to restrict the acceptance of commands that fall below a
+  certain threshold, which can help ensure the smooth functioning of the system.
+  E.g., exclusion bounds can be set to limit the minimum charging power to a
+  sufficiently high level, preventing a peak-shaver client from sending charge
+  powers that are too low when a DC heater client is executing a charge pulse.
+  This can significantly improve the overall performance of the DC heating
+  mechanism.
+
+  The RPC `SetBounds` has been deprecated.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,30 @@
   The current _i_ A at the grid connection point must comply with the
   following constraint: : `-rated_fuse_current <= i <= rated_fuse_current`
 
+* [Introduced exclusion bounds](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/39).
+  In the messages `common.Metric` and `common.MetricAggregation`,
+  `system_bounds` has now been replaced by `system_exclusion_bounds` and
+  `system_inclusion_bounds`. A metric's `value` now has to comply with the
+  following constraints:
+
+  * `value <= system_exclusion_bounds.lower` OR
+    `system_exclusion_bounds.upper <= value`
+
+  * `system_inclusion_bounds.lower <= value <= system_inclusion_bounds.upper`
+
+  `system_inclusion_bounds` behave in the same manner as the earlier
+  `system_bounds`.
+
+  The following diagram illustrates the relationship between the exclusion and
+  inclusion bounds.
+  ```
+    inclusion.lower                              inclusion.upper
+  <-------|============|------------------|============|--------->
+                 exclusion.lower    exclusion.upper
+  ```
+  `----` values here are disallowed and wil be rejected, and
+  `====` values here are allowed and will be accepted.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/proto/frequenz/api/microgrid/common.proto
+++ b/proto/frequenz/api/microgrid/common.proto
@@ -34,8 +34,61 @@ message Metric {
   // originates from.
   Bounds component_bounds = 3;
 
-  // The current bounds of the metric, as imposed by the overall system.
-  Bounds system_bounds = 4;
+  // These bounds indicate the range of values that are disallowed for the
+  // metric.
+  // If these bounds for a metric are [`lower`, `upper`], then this metric's
+  // `value` needs to comply with the constraints
+  // `value <= lower` OR `upper <= value`.
+  //
+  // It is important to note that these bounds work together with
+  // `system_inclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with values that
+  // are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  Bounds system_exclusion_bounds = 4;
+
+  // These bounds indicate the range of values that are allowed for the metric.
+  // If these bounds for a metric are [`lower`, `upper`], then this metric's
+  // `value` needs to comply with the constraint `lower <= value <= upper`
+  //
+  // It is important to note that these bounds work together with
+  // `system_exclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with values that
+  // are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  Bounds system_inclusion_bounds = 5;
 }
 
 // Metrics depicted as a collection of statistical summaries.
@@ -67,8 +120,61 @@ message MetricAggregation {
   // originates from.
   Bounds component_bounds = 14;
 
-  // The current bounds of the metric, as imposed by the overall system.
-  Bounds system_bounds = 15;
+  // These bounds indicate the range of values that are disallowed for the
+  // metric.
+  // If these bounds for a metric are [`lower`, `upper`], then this metric's
+  // `value` needs to comply with the constraints
+  // `value <= lower` OR `upper <= value`.
+  //
+  // It is important to note that these bounds work together with
+  // `system_inclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with power values
+  // that are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  Bounds system_exclusion_bounds = 4;
+
+  // These bounds indicate the range of values that are allowed for the metric.
+  // If these bounds for a metric are [`lower`, `upper`], then this metric's
+  // `value` needs to comply with the constraint `lower <= value <= upper`
+  //
+  // It is important to note that these bounds work together with
+  // `system_exclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with power values
+  // that are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  Bounds system_inclusion_bounds = 5;
 }
 
 // Metrics of a DC electrical connection.

--- a/proto/frequenz/api/microgrid/common.proto
+++ b/proto/frequenz/api/microgrid/common.proto
@@ -30,12 +30,12 @@ message Metric {
   // overall system.
   Bounds rated_bounds = 2;
 
-  // The current bounds of the metric, as imposed by the overall system.
-  Bounds system_bounds = 3;
-
   // The current bounds of the metric, as imposed by the component this metric
   // originates from.
-  Bounds component_bounds = 4;
+  Bounds component_bounds = 3;
+
+  // The current bounds of the metric, as imposed by the overall system.
+  Bounds system_bounds = 4;
 }
 
 // Metrics depicted as a collection of statistical summaries.
@@ -58,17 +58,17 @@ message MetricAggregation {
   // The array of all the metric values.
   repeated float raw_values = 12;
 
-  // The current bounds of the metric, as imposed by the overall system.
-  Bounds system_bounds = 13;
+  // The manufacturer's rated bounds of the metric. This may differ from
+  // `system_bounds` as it does not take into account the current state of the
+  // overall system.
+  Bounds rated_bounds = 13;
 
   // The current bounds of the metric, as imposed by the component this metric
   // originates from.
   Bounds component_bounds = 14;
 
-  // The manufacturer's rated bounds of the metric. This may differ from
-  // `system_bounds` as it does not take into account the current state of the
-  // overall system.
-  Bounds rated_bounds = 15;
+  // The current bounds of the metric, as imposed by the overall system.
+  Bounds system_bounds = 15;
 }
 
 // Metrics of a DC electrical connection.

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -93,7 +93,94 @@ service Microgrid {
   }
 
   // Sets the bounds for a given bounded metric of a given component.
-  rpc SetBounds(stream SetBoundsParam) returns (google.protobuf.Empty);
+  rpc SetBounds(stream SetBoundsParam) returns (google.protobuf.Empty) {
+    option deprecated = true;
+  }
+
+  // Adds exclusion bounds for a given metric of a given component, and returns
+  // the UTC timestamp until which the given exclusion bounds will stay in
+  // effect.
+  //
+  // Exclusion bounds refer to the range of values that are disallowed for the
+  // metric. If these bounds for a metric are [`lower`, `upper`], then this
+  // metric's `value` needs to comply with the constraints
+  // `value <= lower` OR `upper <= value`.
+  //
+  // Exclusion bounds are a useful tool for enhancing the performance of a
+  // system. They can be used to restrict the acceptance of commands that fall
+  // below a certain threshold, which can help ensure the smooth functioning of
+  // the system.
+  // E.g., exclusion bounds can be set to limit the minimum charging power to a
+  // sufficiently high level, preventing a peak-shaver client from sending
+  // charge powers that are too low when a DC heater client is executing a
+  // charge pulse. This can significantly improve the overall performance of the
+  // DC heating mechanism.
+  //
+  //
+  // If multiple exclusion bounds have been provided bor a metric, then the
+  // aggregated lower and upper exclusion bounds are calculated as follows:
+  // lower: the minimum of all lower exclusion bounds
+  // upper: the maximum of all upper exclusion bounds
+  //
+  // It is important to note that these bounds work together with
+  // `system_inclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with values that
+  // are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  rpc AddExclusionBounds(SetBoundsParam) returns (google.protobuf.Timestamp);
+
+  // Adds inclusion bounds for a given metric of a given component, and returns
+  // the UTC timestamp until which the given inclusion bounds will stay in
+  // effect.
+  //
+  // Inclusion bounds refer to the range of values that are allowed for the
+  // metric. If these bounds for a metric are [`lower`, `upper`], then this
+  // metric's `value` needs to comply with the constraint
+  // `lower <= value <= upper`.
+  //
+  // If multiple inclusion bounds have been provided bor a metric, then the
+  // aggregated lower and upper inclusion bounds are calculated as follows:
+  // lower: the maximum of all lower inclusion bounds
+  // upper: the minimum of all upper inclusion bounds
+  //
+  // It is important to note that these bounds work together with
+  // `system_exclusion_bounds`.
+  //
+  // E.g., for the system to accept a charge command,
+  // clients need to request power values within the bounds
+  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
+  // This means that clients can only request charge commands with values that
+  // are within the `system_inclusion_bounds`, but not within
+  // `system_exclusion_bounds`.
+  // Similarly, for the system to accept a discharge command,
+  // clients need to request power values within the bounds
+  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
+  //
+  // The following diagram illustrates the relationship between the bounds.
+  // ```
+  //   inclusion.lower                              inclusion.upper
+  // <-------|============|------------------|============|--------->
+  //                exclusion.lower    exclusion.upper
+  // ```
+  // ---- values here are disallowed and wil be rejected
+  // ==== vales here are allowed and will be accepted
+  rpc AddInclusionBounds(SetBoundsParam) returns (google.protobuf.Timestamp);
 
   // Sets the charge power of a component with a given ID, provided the
   // component supports it.


### PR DESCRIPTION
  In the message `common.Metric`, `system_bounds` has now been replaced by `system_bounds_min` and `system_bounds_max`. A metric value `v` should now follow the following constraint:
  `v >= system_bounds_max.lower` AND `v <= system_bounds_min.lower` AND `v >= system_bounds_min.upper` AND `v <= system_bounds_max.upper`

  Also, two new simple RPCs have been added:
  * `AddMinBounds`: adds a minimum bound pair, and returns the UTC timestamp until when it will stay in effect.
  * `AddMaxBounds`: adds a maximum bound pair, and returns the UTC timestamp until when it will stay in effect.

  and the RPC `SetBounds` has been deprecated.