### PR TITLE
Rename a few RPCs to improve clarity

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,9 +13,11 @@
 * [Added new RPC to return the microgrid metadata](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/30).
   The microgrid metadata consists of information about the overall microgrid,
   as opposed to its components, e.g., the microgrid ID, location, etc.
-  This change adds a new RPC `GetMetadata()` that allows users to fetch
+  This change adds a new RPC `GetMicrogridMetadata()` that allows users to fetch
   microgrid metadata. The returned value is an instance of the message
   `Metadata`.
+
+  Further changes were introduced to this addition in [this PR](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/43).
 
 * [Added enum variants for setting bounds on currents](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/33).
   This will allow clients to set bounds on a components
@@ -84,6 +86,11 @@
   mechanism.
 
   The RPC `SetBounds` has been deprecated.
+
+* [Renamed RPCs](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/43).
+  The following RPC has been renamed to make their objectives clearer:
+  * `GetMetadata` -> `GetMicrogridMetadata`
+  * `GetComponentData` -> `StreamComponentData`
 
 * [Removed deprecated code](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/44)
   The following deprecated code has been removed:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,7 @@
   as opposed to its components, e.g., the microgrid ID, location, etc.
   This change adds a new RPC `GetMicrogridMetadata()` that allows users to fetch
   microgrid metadata. The returned value is an instance of the message
-  `Metadata`.
+  `MicrogridMetadata`.
 
   Further changes were introduced to this addition in [this PR](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/43).
 

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -28,7 +28,7 @@ service Microgrid {
   /// The metadata consists of information that describes the overall
   /// microgrid, as opposed to its components,
   /// e.g., the microgrid ID, location.
-  rpc GetMicrogridMetadata(google.protobuf.Empty) returns (Metadata) {
+  rpc GetMicrogridMetadata(google.protobuf.Empty) returns (MicrogridMetadata) {
     option (google.api.http) = {
       get : "v1/metadata"
     };
@@ -308,7 +308,7 @@ message Location {
 }
 
 // Metadata that describes a microgrid.
-message Metadata {
+message MicrogridMetadata {
   // The microgrid ID.
   // This is a natural number that uniquely identifies a given microgrid.
   uint64 microgrid_id = 1;

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -28,7 +28,7 @@ service Microgrid {
   /// The metadata consists of information that describes the overall
   /// microgrid, as opposed to its components,
   /// e.g., the microgrid ID, location.
-  rpc GetMetadata(google.protobuf.Empty) returns (Metadata) {
+  rpc GetMicrogridMetadata(google.protobuf.Empty) returns (Metadata) {
     option (google.api.http) = {
       get : "v1/metadata"
     };
@@ -79,7 +79,7 @@ service Microgrid {
   }
 
   // Returns a stream containing data from a component with a given ID.
-  rpc GetComponentData(ComponentIdParam) returns (stream ComponentData) {
+  rpc StreamComponentData(ComponentIdParam) returns (stream ComponentData) {
     option (google.api.http) = {
       get : "/v1/components/{id}/data"
     };


### PR DESCRIPTION
The RPC being renamed here are the ones that fetch microgrid and component metadata, and live component data.

The following RPC has been renamed to make their objectives clearer:
  * `GetMetadata` -> `GetMicrogridMetadata`
  * `ListComponents` -> `ListComponentMetadata`
  * `GetComponentData` -> `StreamComponentData`