### PR TITLE
Support solar and battery DC links for inverters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,15 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including if there are any deprecations and what they should be replaced with -->
+* [Updated inverters' DC links to support hybrid and solar inverters](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/50)
+
+  The `Inverter` message has been updated to support hybrid and solar inverters.
+  The `dc` field has been renamed to `dc_battery`, and a new field `dc_solar`
+  has been added.
+  The `dc_battery` field is used to report the DC electricity flowing to/from
+  the linked battery, and is applicable to battery and hybrid inverters.
+  The `dc_solar` field is used to report the DC electricity flowing to/from the
+  linked solar panels, and is applicable to solar and hybrid inverters.
 
 ## New Features
 

--- a/proto/frequenz/api/microgrid/inverter.proto
+++ b/proto/frequenz/api/microgrid/inverter.proto
@@ -90,8 +90,13 @@ message Error {
 
 // Inverter data.
 message Data {
-  // DC metrics of the inverter.
-  common.DC dc = 1;
+  // DC metrics for the inverter-battery linkage.
+  // This is applicable to `BATTERY` and `HYBRID` inverters only.
+  common.DC dc_battery = 4;
+
+  // DC metrics for the inverter-PV linkage.
+  // This is applicable to `SOLAR` and `HYBRID` inverters only.
+  common.DC dc_solar = 5;
 
   // AC metrics of the inverter.
   common.AC ac = 2;


### PR DESCRIPTION
The `Inverter` message has been updated to support hybrid and solar inverters.

The `dc` field has been renamed to `dc_battery`, and a new field `dc_solar` has been added. The `dc_battery` field is used to report the DC electricity flowing to/from the battery, and the `dc_solar` field is used to report the DC electricity flowing to/from the solar panels.