### PR TITLE
Add enum variant for setting bounds on AC reactive power

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,9 @@
   This metric has now been added to the `SensorMetric` enum as
   `SENSOR_METRIC_DEW_POINT`.
 
+* [Added enum variant for setting bounds on AC reactive power](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/51)
+    This will allow clients to set bounds on a component's AC reactive power.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -413,6 +413,7 @@ message SetBoundsParam {
     TARGET_METRIC_CURRENT_PHASE_1 = 3;
     TARGET_METRIC_CURRENT_PHASE_2 = 4;
     TARGET_METRIC_CURRENT_PHASE_3 = 5;
+    TARGET_METRIC_POWER_REACTIVE = 6;
   }
 
   // The ID of the target component.


### PR DESCRIPTION
This will allow clients to set bounds on a component's AC reactive power.