### PR TITLE
Use proto definitions from the common API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,10 +53,6 @@ jobs:
         os:
           - ubuntu-20.04
         python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
           - "3.11"
     runs-on: ${{ matrix.os }}
     steps:
@@ -89,7 +85,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
           docker run --rm -v $PWD:$PWD pseudomuto/protoc-gen-doc \
             -I $PWD/proto \
             -I $PWD/submodules/api-common-protos \
+            -I $PWD/submodules/frequenz-api-common/proto \
             --doc_opt=markdown,gen-docs.md --doc_out=$PWD \
             $(find $PWD/proto -name *.proto)
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "api-common-protos"]
 	path = submodules/api-common-protos
 	url = https://github.com/googleapis/api-common-protos.git
+[submodule "frequenz-api-common"]
+	path = submodules/frequenz-api-common
+	url = https://github.com/frequenz-floss/frequenz-api-common

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,33 @@ If you have any issues with these dependencies, please check the
 `pyproject.toml` file and try installing the exact supported versions instead.
 
 
+Upgrading dependencies
+======================
+
+If you want to update the dependency `frequenz-api-common`, then you need to
+* update the submodule `frequenz-api-common`
+* update the version of the `frequenz-api-common` package in `pyproject.toml`
+* update the version of the `frequenz-api-common` package in
+`minimum-requirements-ci.txt`
+
+The version of `frequenz-api-common` used in all the three places mentioned
+above should be the same.
+
+Here is an example of upgrading the `frequenz-api-common` dependency to version
+`v0.2.0`:
+```sh
+ver="0.2.0"
+
+cd submodules/frequenz-api-common
+git remote update
+git checkout v${ver}
+cd ../..
+
+sed s/"frequenz-api-common == [0-9]\.[0-9]\.[0-9]"/"frequenz-api-common == ${ver}"/g -i pyproject.toml
+
+sed s/"frequenz-api-common == .*"/"frequenz-api-common == ${ver}"/g -i minimum-requirements-ci.txt
+```
+
 Releasing
 =========
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ exclude tox.ini
 recursive-exclude .github *
 recursive-exclude pytests *
 recursive-include submodules/api-common-protos/google *.proto
+recursive-include submodules/frequenz-api-common/proto/frequenz *.proto

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,19 @@
   * `inverter.Type` -> `frequenz.api.common.components.InverterType`
   * `sensor.Type` -> `frequenz.api.common.components.SensorType`
 
+  The pypi package `frequenz-api-common` is being added as a dependency to the
+  python package definition, instead of generating the proto definitions using
+  `protoc`. This is required, otherwise each proto library depending on
+  `frequenz-api-common` will generate its own python modules for
+  `frequenz-api-common`, resulting in multiple definition of the common data
+  structures.
+
+* [Upgraded minimum required python version for the python library to 3.11](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/57)
+
+  The change to use the `frequenz-api-common` definitions forces the minimum
+  required python version of the `frequenz-api-microgrid` package to be 3.11,
+  as a transitive dependency inherited from the `frequenz-api-common` package.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,19 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including if there are any deprecations and what they should be replaced with -->
+* [Using `frequenz-api-common` for common proto definitions](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/57)
+
+  The following proto definitions have been removed, and are being used from the
+  `frequenz-api-common` repository instead:
+  * `ComponentCategory` -> `frequenz.api.common.components.ComponentCategory`
+  * `battery.Type` -> `frequenz.api.common.components.BatteryType`
+  * `common.Bounds` -> `frequenz.api.common.metrics.Bounds`
+  * `common.Metric` -> `frequenz.api.common.metrics.Metric`
+  * `common.Ac` -> `frequenz.api.common.metrics.electrical.Ac`
+  * `common.Dc` -> `frequenz.api.common.metrics.electrical.Dc`
+  * `ev_charger.Type` -> `frequenz.api.common.components.EVChargerType`
+  * `inverter.Type` -> `frequenz.api.common.components.InverterType`
+  * `sensor.Type` -> `frequenz.api.common.components.SensorType`
 
 ## New Features
 

--- a/minimum-requirements-ci.txt
+++ b/minimum-requirements-ci.txt
@@ -1,2 +1,1 @@
-googleapis-common-protos == 1.56.2
-grpcio == 1.47.0
+frequenz-api-common == 0.2.0

--- a/proto/frequenz/api/microgrid/battery.proto
+++ b/proto/frequenz/api/microgrid/battery.proto
@@ -12,25 +12,13 @@ package frequenz.api.microgrid.battery;
 
 import "frequenz/api/microgrid/common.proto";
 
-// Enumerated battery types.
-enum Type {
-  // Unspecified.
-  TYPE_UNSPECIFIED = 0;
-
-  // Li-ion batteries.
-  TYPE_LI_ION = 1;
-
-  // Lithium-Iron-Phosphate batteries.
-  TYPE_LI_FE_PO = 2;
-
-  // Sodium-ion batteries
-  TYPE_NA_ION = 3;
-}
+import "frequenz/api/common/components.proto";
+import "frequenz/api/common/metrics/electrical.proto";
 
 // The battery metadata.
 message Metadata {
   // The battery type.
-  Type type = 1;
+  frequenz.api.common.components.BatteryType type = 1;
 }
 
 enum ComponentState {
@@ -175,7 +163,7 @@ message Error {
 // Battery data.
 message Data {
   // DC electricity metrics.
-  common.DC dc = 1;
+  frequenz.api.common.metrics.electrical.DC dc = 1;
 
   // Battery's overall SoC.
   // In percent (%).

--- a/proto/frequenz/api/microgrid/common.proto
+++ b/proto/frequenz/api/microgrid/common.proto
@@ -10,86 +10,7 @@ syntax = "proto3";
 
 package frequenz.api.microgrid.common;
 
-// A set of lower and upper bounds for any metric.
-// The units of the bounds are always the same as the related metric.
-message Bounds {
-  // The lower bound.
-  float lower = 1;
-
-  // The upper bound.
-  float upper = 2;
-}
-
-// A metric's value, with optional limits.
-message Metric {
-  // The current value of the metric.
-  float value = 1;
-
-  // The manufacturer's rated bounds of the metric. This may differ from
-  // `system_bounds` as it does not take into account the current state of the
-  // overall system.
-  Bounds rated_bounds = 2;
-
-  // The current bounds of the metric, as imposed by the component this metric
-  // originates from.
-  Bounds component_bounds = 3;
-
-  // These bounds indicate the range of values that are disallowed for the
-  // metric.
-  // If these bounds for a metric are [`lower`, `upper`], then this metric's
-  // `value` needs to comply with the constraints
-  // `value <= lower` OR `upper <= value`.
-  //
-  // It is important to note that these bounds work together with
-  // `system_inclusion_bounds`.
-  //
-  // E.g., for the system to accept a charge command,
-  // clients need to request power values within the bounds
-  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
-  // This means that clients can only request charge commands with values that
-  // are within the `system_inclusion_bounds`, but not within
-  // `system_exclusion_bounds`.
-  // Similarly, for the system to accept a discharge command,
-  // clients need to request power values within the bounds
-  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
-  //
-  // The following diagram illustrates the relationship between the bounds.
-  // ```
-  //   inclusion.lower                              inclusion.upper
-  // <-------|============|------------------|============|--------->
-  //                exclusion.lower    exclusion.upper
-  // ```
-  // ---- values here are disallowed and wil be rejected
-  // ==== vales here are allowed and will be accepted
-  Bounds system_exclusion_bounds = 4;
-
-  // These bounds indicate the range of values that are allowed for the metric.
-  // If these bounds for a metric are [`lower`, `upper`], then this metric's
-  // `value` needs to comply with the constraint `lower <= value <= upper`
-  //
-  // It is important to note that these bounds work together with
-  // `system_exclusion_bounds`.
-  //
-  // E.g., for the system to accept a charge command,
-  // clients need to request power values within the bounds
-  // `[system_inclusion_bounds.lower, system_exclusion_bounds.lower]`.
-  // This means that clients can only request charge commands with values that
-  // are within the `system_inclusion_bounds`, but not within
-  // `system_exclusion_bounds`.
-  // Similarly, for the system to accept a discharge command,
-  // clients need to request power values within the bounds
-  // `[system_exclusion_bounds.upper, system_inclusion_bounds.upper]`.
-  //
-  // The following diagram illustrates the relationship between the bounds.
-  // ```
-  //   inclusion.lower                              inclusion.upper
-  // <-------|============|------------------|============|--------->
-  //                exclusion.lower    exclusion.upper
-  // ```
-  // ---- values here are disallowed and wil be rejected
-  // ==== vales here are allowed and will be accepted
-  Bounds system_inclusion_bounds = 5;
-}
+import "frequenz/api/common/metrics.proto";
 
 // Metrics depicted as a collection of statistical summaries.
 //
@@ -114,11 +35,11 @@ message MetricAggregation {
   // The manufacturer's rated bounds of the metric. This may differ from
   // `system_bounds` as it does not take into account the current state of the
   // overall system.
-  Bounds rated_bounds = 13;
+  frequenz.api.common.metrics.Bounds rated_bounds = 13;
 
   // The current bounds of the metric, as imposed by the component this metric
   // originates from.
-  Bounds component_bounds = 14;
+  frequenz.api.common.metrics.Bounds component_bounds = 14;
 
   // These bounds indicate the range of values that are disallowed for the
   // metric.
@@ -147,7 +68,7 @@ message MetricAggregation {
   // ```
   // ---- values here are disallowed and wil be rejected
   // ==== vales here are allowed and will be accepted
-  Bounds system_exclusion_bounds = 4;
+  frequenz.api.common.metrics.Bounds system_exclusion_bounds = 4;
 
   // These bounds indicate the range of values that are allowed for the metric.
   // If these bounds for a metric are [`lower`, `upper`], then this metric's
@@ -174,193 +95,7 @@ message MetricAggregation {
   // ```
   // ---- values here are disallowed and wil be rejected
   // ==== vales here are allowed and will be accepted
-  Bounds system_inclusion_bounds = 5;
-}
-
-// Metrics of a DC electrical connection.
-message DC {
-  // The DC voltage across the component.
-  // In Volt (V).
-  Metric voltage = 1;
-
-  // The DC current flowing away from the grid connection.
-  // In passive sign convention:
-  // +ve current means consumption, away from the grid.
-  // -ve current means supply into the grid.
-  // In Ampere (A).
-  Metric current = 2;
-
-  // The DC power flowing away from the grid connection.
-  // In passive sign convention:
-  // +ve power means consumption, away from the grid.
-  // -ve power means supply into the grid.
-  // In Watt (W).
-  Metric power = 3;
-}
-
-// The current state and metrics of the electrical connections to the
-// inverter.
-message AC {
-  // The active energy the inverter is consuming or generating.
-  message ActiveEnergy {
-    // The sum of the consumed and delivered energy.
-    // This is a signed value in passive sign convention: if more energy is
-    // consumed than delivered, this is a -ve number, otherwise +ve.
-    // In Watt-hour (Wh).
-    Metric energy = 1;
-
-    // The consumed energy.
-    // In Watt-hour (Wh).
-    Metric energy_consumed = 2;
-
-    // The delivered energy.
-    // In Watt-hour (Wh).
-    Metric energy_delivered = 3;
-  }
-
-  // The reactive energy the inverter is consuming or generating.
-  message ReactiveEnergy {
-    // The sum of the capacitive and inductive energy.
-    // This is a signed value. If more energy is capacitive than inductive,
-    // this is a -ve number, otherwise +ve.
-    // In Volt-Ampere-hour (VArh).
-    Metric energy = 1;
-
-    // The capacitive energy.
-    // In Volt-Ampere-hour (VArh).
-    Metric energy_capacitive = 2;
-
-    // The inductive energy.
-    // In Volt-Ampere-hour (VArh).
-    Metric energy_inductive = 3;
-  }
-
-  // The harmonics of the fast Fourier transform of the instantaneous values
-  // and its total harmonic distortion.
-  // In percent (%).
-  message Harmonics {
-    float harmonic_1 = 1;
-    float harmonic_2 = 2;
-    float harmonic_3 = 3;
-    float harmonic_4 = 4;
-    float harmonic_5 = 5;
-    float harmonic_6 = 6;
-    float harmonic_7 = 7;
-    float harmonic_8 = 8;
-    float harmonic_9 = 9;
-    float harmonic_10 = 10;
-    float harmonic_11 = 11;
-  }
-
-  // AC metrics of a single phase.
-  message ACPhase {
-    // The AC voltage between the line and the neutral wire.
-    // In Volt (V).
-    Metric voltage = 1;
-
-    // AC current.
-    // +ve current means consumption, away from the grid.
-    // -ve current means supply into the grid.
-    // In Ampere (A).
-    Metric current = 2;
-
-    // AC active power.
-    // +ve power means consumption, away from the grid.
-    // -ve power means supply into the grid.
-    // In Watt (W).
-    Metric power_active = 3;
-
-    // AC reactive power.
-    // +ve power means inductive (leading).
-    // -ve power means capacitive (lagging).
-    // In Volt-Ampere reactive (VAr).
-    Metric power_reactive = 4;
-
-    // The total apparent energy. A Positive value represents the net apparent
-    // energy supplied to the grid connection, and vice versa.
-    // In Volt-Ampere-hour (VAh).
-    Metric energy_apparent = 5;
-
-    // The total active energy counters for the underlying component's
-    // consumption and supply.
-    // In Watt-hour (Wh).
-    ActiveEnergy energy_active = 6;
-
-    // The total reactive energy counters for the underlying component's
-    // capacitive and inductive energy values.
-    // In Volt-Ampere reactive hour (VArh).
-    ReactiveEnergy energy_reactive = 7;
-
-    // Harmonics of the instantaneous active power at the component.
-    // In percent (%).
-    Harmonics harmonics_power_active = 8;
-
-    // Total harmonic distortion
-    // of the instantaneous active power at the component.
-    // In percent (%).
-    float thd_power_active = 9;
-  }
-
-  // Overall AC metrics.
-
-  // The AC frequency.
-  // In Hertz (Hz).
-  Metric frequency = 1;
-
-  // The apparent 3-phase AC current. Positive values represent apparent energy
-  // flowing towards the grid connection, and vice versa.
-  // In Ampere (A).
-  Metric current = 2;
-
-  // The apparent 3-phase AC power. Positive values represent apparent energy
-  // flowing towards the grid connection, and vice versa.
-  // In Volt-Ampere (VA).
-  Metric power_apparent = 3;
-
-  // The total active 3-phase AC active power.
-  // +ve power means consumption, away from the grid.
-  // -ve power means supply into the grid.
-  // In Watt (W).
-  Metric power_active = 4;
-
-  // The reactive 3-phase AC power.
-  // +ve power means inductive (leading).
-  // -ve power means capacitive (lagging).
-  // In Volt-Ampere reactive (VAr).
-  Metric power_reactive = 5;
-
-  // The total 3-phase apparent energy. A positive value represents the net
-  // apparent energy supplied to the grid connection, and vice versa.
-  // In Volt-Ampere-hour (VAh).
-  Metric energy_apparent = 6;
-
-  // The total 3-phase active energy counters for the underlying component's
-  // consumption and supply.
-  // In Watt-hour (Wh).
-  ActiveEnergy energy_active = 7;
-
-  // The total 3-phase reactive energy counters for the underlying component's
-  // capacitive and inductive energy values.
-  // In Volt-Ampere reactive hour (VArh).
-  // FIXME: ReactiveEnergy says Volt-Ampere-hour (VAh).
-  ReactiveEnergy energy_reactive = 8;
-
-  // The sums of the harmonics
-  // of the instantaneous active power at the component across all 3 phases.
-  Harmonics harmonics_power_active = 9;
-
-  // The sums of the total harmonic distortion
-  // of the instantaneous active power at the component across all 3 phases.
-  float thd_power_active = 10;
-
-  // AC metrics for phase/line 1.
-  ACPhase phase_1 = 11;
-
-  // AC metrics for phase/line 2.
-  ACPhase phase_2 = 12;
-
-  // AC metrics for phase/line 3.
-  ACPhase phase_3 = 13;
+  frequenz.api.common.metrics.Bounds system_inclusion_bounds = 5;
 }
 
 // Error levels definitions.

--- a/proto/frequenz/api/microgrid/ev_charger.proto
+++ b/proto/frequenz/api/microgrid/ev_charger.proto
@@ -12,26 +12,14 @@ package frequenz.api.microgrid.ev_charger;
 
 import "frequenz/api/microgrid/common.proto";
 
-
-// The possible types of an EV charging station.
-enum Type {
-  // Default type.
-  TYPE_UNSPECIFIED = 0;
-
-  // The EV charging station supports AC charging only.
-  TYPE_AC = 1;
-
-  // The EV charging station supports DC charging only.
-  TYPE_DC = 2;
-
-  // The EV charging station supports both AC and DC.
-  TYPE_HYBRID = 3;
-}
+import "frequenz/api/common/components.proto";
+import "frequenz/api/common/metrics.proto";
+import "frequenz/api/common/metrics/electrical.proto";
 
 // The EV charger metadata.
 message Metadata {
   // The EV charger type.
-  Type type = 1;
+  frequenz.api.common.components.EVChargerType type = 1;
 }
 
 // The possible states of an EV charging station.
@@ -174,17 +162,17 @@ message Data {
   // Contains data only if DC charging is supported by the EV charging station.
   // (in which case, the type of the EV charging station is TYPE_DC or
   // TYPE_HYBRID)
-  common.DC dc = 1;
+  frequenz.api.common.metrics.electrical.DC dc = 1;
 
   // AC metrics of the EV charging station.
   // Contains data only if AC charging is supported by the EV charging station.
   // (in which case, the type of the EV charging station is TYPE_AC or
   // TYPE_HYBRID)
-  common.AC ac = 2;
+  frequenz.api.common.metrics.electrical.AC ac = 2;
 
   // The overall temperature of the EV charger.
   // In degree Celsius (°C).
-  common.Metric temperature = 3;
+  frequenz.api.common.metrics.Metric temperature = 3;
 }
 
 // EV charger properties.

--- a/proto/frequenz/api/microgrid/inverter.proto
+++ b/proto/frequenz/api/microgrid/inverter.proto
@@ -12,6 +12,10 @@ package frequenz.api.microgrid.inverter;
 
 import "frequenz/api/microgrid/common.proto";
 
+import "frequenz/api/common/components.proto";
+import "frequenz/api/common/metrics.proto";
+import "frequenz/api/common/metrics/electrical.proto";
+
 // Enumerated inverter types.
 enum Type {
   TYPE_UNSPECIFIED = 0;
@@ -23,7 +27,7 @@ enum Type {
 // The inverter metadata.
 message Metadata {
   // The inverter type.
-  Type type = 1;
+  frequenz.api.common.components.InverterType type = 1;
 }
 
 // Enumerated inverter states.
@@ -92,18 +96,18 @@ message Error {
 message Data {
   // DC metrics for the inverter-battery linkage.
   // This is applicable to `BATTERY` and `HYBRID` inverters only.
-  common.DC dc_battery = 4;
+  frequenz.api.common.metrics.electrical.DC dc_battery = 4;
 
   // DC metrics for the inverter-PV linkage.
   // This is applicable to `SOLAR` and `HYBRID` inverters only.
-  common.DC dc_solar = 5;
+  frequenz.api.common.metrics.electrical.DC dc_solar = 5;
 
   // AC metrics of the inverter.
-  common.AC ac = 2;
+  frequenz.api.common.metrics.electrical.AC ac = 2;
 
   // The verall temperature of the inverter.
   // In degree Celsius (°C).
-  common.Metric temperature = 3;
+  frequenz.api.common.metrics.Metric temperature = 3;
 }
 
 // Inverter properties.

--- a/proto/frequenz/api/microgrid/meter.proto
+++ b/proto/frequenz/api/microgrid/meter.proto
@@ -12,6 +12,8 @@ package frequenz.api.microgrid.meter;
 
 import "frequenz/api/microgrid/common.proto";
 
+import "frequenz/api/common/metrics/electrical.proto";
+
 // Enumerated meter types.
 enum Type {
   TYPE_UNSPECIFIED = 0;
@@ -74,7 +76,7 @@ message Error {
 // Meter data.
 message Data {
   // AC metrics of the inverter.
-  common.AC ac = 1;
+  frequenz.api.common.metrics.electrical.AC ac = 1;
 }
 
 // Meter properties.

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -11,12 +11,14 @@ syntax = "proto3";
 package frequenz.api.microgrid;
 
 import "frequenz/api/microgrid/battery.proto";
-import "frequenz/api/microgrid/common.proto";
 import "frequenz/api/microgrid/ev_charger.proto";
 import "frequenz/api/microgrid/grid.proto";
 import "frequenz/api/microgrid/inverter.proto";
 import "frequenz/api/microgrid/meter.proto";
 import "frequenz/api/microgrid/sensor.proto";
+
+import "frequenz/api/common/components.proto";
+import "frequenz/api/common/metrics.proto";
 
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
@@ -317,50 +319,13 @@ message MicrogridMetadata {
   Location location = 2;
 }
 
-// Enumrated component categories.
-enum ComponentCategory {
-  // An unknown component categories, useful for error handling, and marking
-  // unknown components in a list of components with otherwise known categories.
-  COMPONENT_CATEGORY_UNSPECIFIED = 0;
-
-  // The point where the local microgrid is connected to the grid.
-  COMPONENT_CATEGORY_GRID = 1;
-
-  // A meter, for measuring electrical metrics, e.g., current, voltage, etc.
-  COMPONENT_CATEGORY_METER = 2;
-
-  // An electricity generator, with batteries or solar energy.
-  COMPONENT_CATEGORY_INVERTER = 3;
-
-  // A DC-DC converter.
-  COMPONENT_CATEGORY_CONVERTER = 4;
-
-  // A storage system for electrical energy, used by inverters.
-  COMPONENT_CATEGORY_BATTERY = 5;
-
-  // A station for charging electrical vehicles.
-  COMPONENT_CATEGORY_EV_CHARGER = 6;
-
-  // A sensor for measuring ambient metrics, e.g., temperature, humidity, etc.
-  COMPONENT_CATEGORY_SENSOR = 7;
-
-  // A crypto miner.
-  COMPONENT_CATEGORY_CRYPTO_MINER = 8;
-
-  // An electrolyzer for converting water into hydrogen and oxygen.
-  COMPONENT_CATEGORY_ELECTROLYZER = 9;
-
-  // A heat and power combustion plant (CHP stands for combined heat and power).
-  COMPONENT_CATEGORY_CHP = 10;
-}
-
 // Parameters for filtering the components.
 message ComponentFilter {
   // Return components that have the specified IDs only.
   repeated uint64 ids = 1;
 
   // Return components that have the specified categories only.
-  repeated ComponentCategory categories = 2;
+  repeated frequenz.api.common.components.ComponentCategory categories = 2;
 }
 
 // Encapsulation of a component ID, intended to be used as a parameter for rpc
@@ -423,7 +388,7 @@ message SetBoundsParam {
   TargetMetric target_metric = 2;
 
   // The bounds for the target metric.
-  common.Bounds bounds = 3;
+  frequenz.api.common.metrics.Bounds bounds = 3;
 }
 
 // A generic message for components. It is used to represent any category of
@@ -436,7 +401,7 @@ message Component {
   string name = 2;
 
   // The category of the component.
-  ComponentCategory category = 3;
+  frequenz.api.common.components.ComponentCategory category = 3;
 
   // The component manufacturer.
   string manufacturer = 4;

--- a/proto/frequenz/api/microgrid/sensor.proto
+++ b/proto/frequenz/api/microgrid/sensor.proto
@@ -12,37 +12,12 @@ package frequenz.api.microgrid.sensor;
 
 import "frequenz/api/microgrid/common.proto";
 
-// Enumerated sensor types.
-enum Type {
-  // Unspecified
-  TYPE_UNSPECIFIED = 0;
-
-  // Thermometer (temperature sensor)
-  TYPE_THERMOMETER = 1;
-
-  // Hygrometer (humidity sensor)
-  TYPE_HYGROMETER = 2;
-
-  // Barometer (pressure sensor).
-  TYPE_BAROMETER = 3;
-
-  // Pyranometer (solar irradiance sensor).
-  TYPE_PYRANOMETER = 4;
-
-  // Anemometer (wind velocity and direction sensor).
-  TYPE_ANEMOMETER = 5;
-
-  // Accelerometers (acceleration sensor).
-  TYPE_ACCELEROMETER = 6;
-
-  // General sensors, which do not fall in any of the above categories
-  TYPE_GENERAL = 7;
-}
+import "frequenz/api/common/components.proto";
 
 // The sensor metadata.
 message Metadata {
   // The sensor type.
-  Type type = 1;
+  frequenz.api.common.components.SensorType type = 1;
 }
 
 // Enumerated sensor states.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,11 @@ classifiers = [
    "License :: OSI Approved :: MIT License",
    "Programming Language :: Python :: 3",
    "Programming Language :: Python :: 3 :: Only",
-   "Programming Language :: Python :: 3.7",
-   "Programming Language :: Python :: 3.8",
-   "Programming Language :: Python :: 3.9",
-   "Programming Language :: Python :: 3.10",
    "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">= 3.7, < 4"
+requires-python = ">= 3.11, < 4"
 dependencies = [
+    "frequenz-api-common == 0.2.0",
     "googleapis-common-protos >= 1.56.2, < 2",
     "grpcio >= 1.47.0, < 2",
 ]

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ class CompileProto(setuptools.Command):
             + """-m grpc_tools.protoc
                     -I proto
                     -I submodules/api-common-protos
+                    -I submodules/frequenz-api-common/proto
                     --python_out=py
                     --grpc_python_out=py
                     --mypy_out=py


### PR DESCRIPTION
The following proto definitions have been removed, and are being used from the `frequenz-api-common` repository instead:

* `ComponentCategory` -> `frequenz.api.common.components.ComponentCategory`
* `battery.Type` -> `frequenz.api.common.components.BatteryType`
* `common.Bounds` -> `frequenz.api.common.metrics.Bounds`
* `common.Metric` -> `frequenz.api.common.metrics.Metric`
* `common.Ac` -> `frequenz.api.common.metrics.electrical.Ac`
* `common.Dc` -> `frequenz.api.common.metrics.electrical.Dc`
* `ev_charger.Type` -> `frequenz.api.common.components.EVChargerType`
* `inverter.Type` -> `frequenz.api.common.components.InverterType`
* `sensor.Type` -> `frequenz.api.common.components.SensorType`

The pypi package `frequenz-api-common` is being added as a dependency to the python package definition, instead of generating the proto definitions using `protoc`. This is required, otherwise each proto library depending on `frequenz-api-common` will generate its own python modules for `frequenz-api-common`, resulting in multiple definition of the common data structures.

Note that this forces the minimum required python version of the `frequenz-api-microgrid` package to be 3.11, as a transitive dependency inherited from the `frequenz-api-common` package.