### PR TITLE
Extend component states for battery, EV charger, and inverter components

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,9 +38,13 @@
 * [Added new battery component states](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/59)
 
   Three new battery component states have been added:
-  * SwitchingOn
-  * SwitchingOff
-  * Unknown
+  * `SwitchingOn`
+  * `SwitchingOff`
+  * `Unknown`
+
+* [Added a new EV charger component state](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/59)
+
+  A new EV charger component states have been added: `Unknown`
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,10 @@
 
   A new EV charger component states have been added: `Unknown`
 
+* [Added a new inverter component state](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/59)
+
+  A new inverter component states have been added: `Unknown`
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,7 +35,12 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* [Added new battery component states](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/59)
+
+  Three new battery component states have been added:
+  * SwitchingOn
+  * SwitchingOff
+  * Unknown
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/microgrid/battery.proto
+++ b/proto/frequenz/api/microgrid/battery.proto
@@ -23,6 +23,7 @@ message Metadata {
 
 enum ComponentState {
   // Default value.
+  // This value is used only when the state information is not available.
   COMPONENT_STATE_UNSPECIFIED = 0;
 
   // The battery is switched off.
@@ -43,6 +44,16 @@ enum ComponentState {
   // The battery is online, but currently unavailable, possibly due to
   // a pre-scheduled maintenance, or waiting for a resource to be loaded.
   COMPONENT_STATE_LOCKED = 6;
+
+  // The battery is starting up and needs some time to become fully operational.
+  COMPONENT_STATE_SWITCHING_ON = 7;
+
+  // The battery is switching off and needs some time to fully shut down.
+  COMPONENT_STATE_SWITCHING_OFF = 8;
+
+  // The state is provided by the device, but it can not be parsed as any of the
+  // above (known) states.
+  COMPONENT_STATE_UNKNOWN = 9;
 }
 
 enum RelayState {

--- a/proto/frequenz/api/microgrid/ev_charger.proto
+++ b/proto/frequenz/api/microgrid/ev_charger.proto
@@ -25,6 +25,7 @@ message Metadata {
 // The possible states of an EV charging station.
 enum ComponentState {
   // Default state.
+  // This value is used only when the state information is not available.
   COMPONENT_STATE_UNSPECIFIED = 0;
 
   // The EV charging station is starting up.
@@ -51,6 +52,10 @@ enum ComponentState {
 
   // The EV charging process hes been temporarily interrupted.
   COMPONENT_STATE_INTERRUPTED = 8;
+
+  // The state is provided by the device, but it can not be parsed as any of the
+  // above (known) states.
+  COMPONENT_STATE_UNKNOWN = 9;
 }
 
 // The possible states of the cable connecting an EV charging station and an

--- a/proto/frequenz/api/microgrid/inverter.proto
+++ b/proto/frequenz/api/microgrid/inverter.proto
@@ -66,6 +66,10 @@ enum ComponentState {
   // The inverter is online, but currently unavailable, possibly due to
   // a pre-scheduled maintenance.
   COMPONENT_STATE_UNAVAILABLE = 15;
+
+  // The state is provided by the device, but it can not be parsed as any of the
+  // above (known) states.
+  COMPONENT_STATE_UNKNOWN = 16;
 }
 
 // Enumerated inverter error codes.


### PR DESCRIPTION
Three new battery component states have been added:
  * `SwitchingOn`
  * `SwitchingOff`
  * `Unknown`

A new EV charger component states have been added: `Unknown`

A new inverter component states have been added: `Unknown`