### PR TITLE
Bump the frequenz-api-common package

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,3 +18,7 @@
 
   This bug prevented building the gRPC gateway for the microgrid API.
   This fix should allow the gRPC gateway builds again.
+
+* [Bumped `frequenz-api-common` Python dependency](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/67)
+
+  The `frequenz-api-common` submodule was bumped in the previous release but the Python package was forgotten.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-    "frequenz-api-common == 0.2.0",
+    "frequenz-api-common == 0.3.0",
     "googleapis-common-protos >= 1.56.2, < 2",
     "grpcio >= 1.47.0, < 2",
 ]


### PR DESCRIPTION
The submodule was updated in a previous PR but the Python package was forgotten.