### PR TITLE
Add missing leading `/` to `GetMicrogridMetadata()`'s HTTP endpoint

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,32 +2,16 @@
 
 ## Summary
 
-This release upgrades the submodule `frequenz-api-common` to v0.3.0, and
-renames the message `EVCharger` to `EvCharger`.
+<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 
-* [Upgraded `frequenz-api-common` to v0.3.0](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/65)
-
-  The submodule `frequenz-api-common` has been upgraded to v0.3.0.
-  This version renames the enum representing EV charger types to `EvChargerType`
-  and defined the `MetricAggregation` message, which was previously defined in
-  `frequenz-api-microgrid`.
-
-  Since the message `MetricAggregation` is now being imported from the common
-  specs, it has been removed from the file `common.proto`.
-
-* [Renamed message `EVCharger` to `EvCharger`](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/65)
-
-  This is done to use same naming convention as `frequenz-api-common`.
-  Note that a similar renaming was done in `frequenz-api-common` v0.3.0 to
-  improve the code quality of the derived rust code using prost.
-
+<!-- Here goes notes on how to upgrade from previous versions, including if there are any deprecations and what they should be replaced with -->
 
 ## New Features
 
-None
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 
-None
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,7 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* [Added missing leading `/` to `GetMicrogridMetadata()`'s HTTP endpoint](https://github.com/frequenz-floss/frequenz-api-microgrid/pull/69)
+
+  This bug prevented building the gRPC gateway for the microgrid API.
+  This fix should allow the gRPC gateway builds again.

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -32,7 +32,7 @@ service Microgrid {
   /// e.g., the microgrid ID, location.
   rpc GetMicrogridMetadata(google.protobuf.Empty) returns (MicrogridMetadata) {
     option (google.api.http) = {
-      get : "v1/metadata"
+      get : "/v1/metadata"
     };
   }
 


### PR DESCRIPTION
This bug prevented building the gRPC gateway for the microgrid API. This fix should allow the gRPC gateway builds again.