### PR TITLE
Revert "Update protobuf file headers"

### DIFF
--- a/proto/frequenz/api/microgrid/battery.proto
+++ b/proto/frequenz/api/microgrid/battery.proto
@@ -1,9 +1,10 @@
 // Contains definitions specific to batteries.
 //
-// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+// Copyright:
+// Copyright 2022 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/microgrid/common.proto
+++ b/proto/frequenz/api/microgrid/common.proto
@@ -1,9 +1,10 @@
 // Contains enums and messages reused throught the Microgrid API definitions.
 //
-// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+// Copyright:
+// Copyright 2022 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/microgrid/ev_charger.proto
+++ b/proto/frequenz/api/microgrid/ev_charger.proto
@@ -1,9 +1,10 @@
 // Contains definitions specific to EV charging stations.
 //
-// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+// Copyright:
+// Copyright 2022 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/microgrid/grid.proto
+++ b/proto/frequenz/api/microgrid/grid.proto
@@ -1,9 +1,10 @@
 // Contains grid connection point details.
 //
+// Copyright:
 // Copyright 2023 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/microgrid/inverter.proto
+++ b/proto/frequenz/api/microgrid/inverter.proto
@@ -1,9 +1,10 @@
 // Contains definitions specific to inverters.
 //
-// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+// Copyright:
+// Copyright 2022 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/microgrid/meter.proto
+++ b/proto/frequenz/api/microgrid/meter.proto
@@ -1,9 +1,10 @@
 // Contains definitions specific to meters.
 //
-// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+// Copyright:
+// Copyright 2022 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -1,9 +1,10 @@
 // Contains the definitions for Microgrid gRPC API.
 //
-// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+// Copyright:
+// Copyright 2022 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 

--- a/proto/frequenz/api/microgrid/sensor.proto
+++ b/proto/frequenz/api/microgrid/sensor.proto
@@ -1,9 +1,10 @@
 // Contains definitions specific to sensors.
 //
-// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+// Copyright:
+// Copyright 2022 Frequenz Energy-as-a-Service GmbH
 //
-// Licensed under the MIT License (the "License");
-// you may not use this file except in compliance with the License.
+// License:
+// MIT
 
 syntax = "proto3";
 


### PR DESCRIPTION
The update was not necessary, the original request for a header change came from a other repository which had a bad license header and didn't take into account the current standard format set in the `repo-config` cookiecutter templates.

This reverts commit 5e1ce9972f827238bea65e0cd8908dc49529d46a.
