### PR TITLE
Remove the `CanStreamData` RPC

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,8 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The `CanStreamData` RPC has been removed. Users are recommended to check it
+  by calling the `StreamComponentData` RPC.
 
 ## New Features
 

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -87,13 +87,6 @@ service Microgrid {
     };
   }
 
-  // Returns whether the component with given ID can stream data.
-  rpc CanStreamData(ComponentIdParam) returns (google.protobuf.BoolValue) {
-    option (google.api.http) = {
-      get : "/v1/components/{id}/canStream"
-    };
-  }
-
   // Adds exclusion bounds for a given metric of a given component, and returns
   // the UTC timestamp until which the given exclusion bounds will stay in
   // effect.


### PR DESCRIPTION
It can be checked by calling the `StreamComponentData` method, and checking if the response is an error or not.