### PR TITLE
Use Location from the common API specs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,10 @@
 
 - `frequenz-api-common` has been updated to `v0.3.1`.
 
+- The message `microgrid.Location` has been removed, and
+  `frequenz.api.common.location.Location` is being used instead. The `Location`
+  message from the common API also has a `country_code` member.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -18,6 +18,7 @@ import "frequenz/api/microgrid/meter.proto";
 import "frequenz/api/microgrid/sensor.proto";
 
 import "frequenz/api/common/components.proto";
+import "frequenz/api/common/location.proto";
 import "frequenz/api/common/metrics.proto";
 
 import "google/api/annotations.proto";
@@ -306,15 +307,6 @@ service Microgrid {
   }
 }
 
-// A pair of geographical co-ordinates, representing the location of a place.
-message Location {
-  // The latitude of the place.
-  float latitude = 1;
-
-  // The longitude of the place.
-  float longitude = 2;
-}
-
 // Metadata that describes a microgrid.
 message MicrogridMetadata {
   // The microgrid ID.
@@ -322,7 +314,7 @@ message MicrogridMetadata {
   uint64 microgrid_id = 1;
 
   // The location of the microgrid, in geographical co-ordinates.
-  Location location = 2;
+  frequenz.api.common.location.Location location = 2;
 }
 
 // Parameters for filtering the components.


### PR DESCRIPTION
Note that the `Location` message from the common API also has a `country_code` member.