### PR TITLE
Rename RPC StreamComponentData to SubscribeComponentData

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,9 @@
   `frequenz.api.common.location.Location` is being used instead. The `Location`
   message from the common API also has a `country_code` member.
 
+- The following gRPC method has been renamed:
+  `StreamComponentData` -> `SubscribeComponentData`
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -82,7 +82,7 @@ service Microgrid {
   }
 
   // Returns a stream containing data from a component with a given ID.
-  rpc StreamComponentData(ComponentIdParam) returns (stream ComponentData) {
+  rpc SubscribeComponentData(ComponentIdParam) returns (stream ComponentData) {
     option (google.api.http) = {
       get : "/v1/components/{id}/data"
     };


### PR DESCRIPTION
Using `stream` as a verb can be ambigous. It could mean publishing and subscribing to a data stream. `Subscribe` is a more unambiguous option.