### PR TITLE
Rename precharge_module to precharger

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,7 +33,7 @@
   - `StartComponent`
   - `StopComponent`
 
-- Added support for a new Component category: Precharge modules.
+- Added support for a new Component category: Precharger.
   Precharging a DC (Direct Current) bus refers to a controlled process in
   electrical systems, e.g., when connecting an inverter to a battery, where the
   voltage across a DC bus is gradually increased from a low level to a desired

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -15,7 +15,7 @@ import "frequenz/api/microgrid/ev_charger.proto";
 import "frequenz/api/microgrid/grid.proto";
 import "frequenz/api/microgrid/inverter.proto";
 import "frequenz/api/microgrid/meter.proto";
-import "frequenz/api/microgrid/precharge_module.proto";
+import "frequenz/api/microgrid/precharger.proto";
 import "frequenz/api/microgrid/relay.proto";
 import "frequenz/api/microgrid/sensor.proto";
 
@@ -470,7 +470,7 @@ message ComponentData {
     ev_charger.EvCharger ev_charger = 6;
     sensor.Sensor sensor = 7;
     relay.Relay relay = 8;
-    precharge_module.PrechargeModule precharge_module = 9;
+    precharger.Precharger precharger = 9;
   }
 }
 

--- a/proto/frequenz/api/microgrid/precharger.proto
+++ b/proto/frequenz/api/microgrid/precharger.proto
@@ -15,7 +15,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.precharge_module;
+package frequenz.api.microgrid.precharger;
 
 import "frequenz/api/microgrid/common.proto";
 
@@ -62,8 +62,8 @@ message Error {
   string msg = 3;
 }
 
-// PrechargeModule details.
-message PrechargeModule {
+// Precharger details.
+message Precharger {
   // The component's state.
   State state = 2;
 


### PR DESCRIPTION
This is done to be consistent with the other component names.