### PR TITLE
Change inverter DC metrics to repeated fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,8 @@
 
 - Upgraded the `frequenz-api-common` package to `v0.4.0`.
 
+- Changed inverter DC metrics to repeated fields.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/microgrid/inverter.proto
+++ b/proto/frequenz/api/microgrid/inverter.proto
@@ -100,11 +100,13 @@ message Error {
 message Data {
   // DC metrics for the inverter-battery linkage.
   // This is applicable to `BATTERY` and `HYBRID` inverters only.
-  frequenz.api.common.v1.metrics.electrical.DC dc_battery = 4;
+  // The inverter may have multiple batteries connected to it.
+  repeated frequenz.api.common.v1.metrics.electrical.DC dc_batteries = 4;
 
   // DC metrics for the inverter-PV linkage.
   // This is applicable to `SOLAR` and `HYBRID` inverters only.
-  frequenz.api.common.v1.metrics.electrical.DC dc_solar = 5;
+  // The inverter may have multiple PV arrays connected to it.
+  repeated frequenz.api.common.v1.metrics.electrical.DC dc_pv_arrays = 5;
 
   // AC metrics of the inverter.
   frequenz.api.common.v1.metrics.electrical.AC ac = 2;


### PR DESCRIPTION
An inverter may have multiple batteries and/or PV arrays connected to it. Hence, the DC metrics for the inverter-battery and inverter-PV linkages are changed to repeated fields.