### PR TITLE
Add fuse component

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,6 +48,9 @@
 
 - Changed inverter DC metrics to repeated fields.
 
+- Added fuse component. Fuses are used to protect electrical components from
+  overcurrent.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/microgrid/fuse.proto
+++ b/proto/frequenz/api/microgrid/fuse.proto
@@ -1,0 +1,28 @@
+// Contains definitions for fuses.
+//
+// The fuse component represents a fuse in the microgrid. It is used to protect
+// components from overcurrents.
+//
+// Copyright:
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// License:
+// MIT
+
+syntax = "proto3";
+
+package frequenz.api.microgrid.fuse;
+
+// The fuse component represents a fuse in the microgrid. It is used to protect
+// components from overcurrents.
+message Metadata {
+  // The rated current of the fuse in amperes.
+  // This is the maximum current that the fuse can withstand for a long time.
+  // This limit applies to currents both flowing in or out of each of the 3
+  // phases individually.
+  //
+  // In other words, a current _i_ A at one of the phases of the node must
+  // comply with the following constraint:
+  // `-rated_fuse_current <= i <= rated_fuse_current`
+  uint32 rated_current = 1;
+}

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -19,6 +19,7 @@ import "frequenz/api/microgrid/meter.proto";
 import "frequenz/api/microgrid/precharger.proto";
 import "frequenz/api/microgrid/relay.proto";
 import "frequenz/api/microgrid/sensor.proto";
+import "frequenz/api/microgrid/voltage_transformer.proto";
 
 import "frequenz/api/common/v1/components.proto";
 import "frequenz/api/common/v1/location.proto";
@@ -447,6 +448,7 @@ message Component {
     ev_charger.Metadata ev_charger = 15;
     sensor.Metadata sensor = 16;
     fuse.Metadata fuse = 17;
+    voltage_transformer.Metadata voltage_transformer = 18;
   }
 }
 

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -12,6 +12,7 @@ package frequenz.api.microgrid;
 
 import "frequenz/api/microgrid/battery.proto";
 import "frequenz/api/microgrid/ev_charger.proto";
+import "frequenz/api/microgrid/fuse.proto";
 import "frequenz/api/microgrid/grid.proto";
 import "frequenz/api/microgrid/inverter.proto";
 import "frequenz/api/microgrid/meter.proto";
@@ -445,6 +446,7 @@ message Component {
     meter.Metadata meter = 14;
     ev_charger.Metadata ev_charger = 15;
     sensor.Metadata sensor = 16;
+    fuse.Metadata fuse = 17;
   }
 }
 

--- a/proto/frequenz/api/microgrid/voltage_transformer.proto
+++ b/proto/frequenz/api/microgrid/voltage_transformer.proto
@@ -1,0 +1,34 @@
+// Contains definitions for voltage transformers.
+//
+// Voltage transformers are used to step up or step down the voltage, keeping
+// the power somewhat constant by increasing or decreasing the current.
+// If voltage is stepped up, current is stepped down, and vice versa.
+// Note that voltage transformers have efficiency losses, so the output power
+// is always less than the input power.
+//
+// Copyright:
+// Copyright 2023 Frequenz Energy-as-a-Service GmbH
+//
+// License:
+// MIT
+
+syntax = "proto3";
+
+package frequenz.api.microgrid.voltage_transformer;
+
+// A voltage transformer.
+// Voltage transformers are used to step up or step down the voltage, keeping
+// the power somewhat constant by increasing or decreasing the current.
+// If voltage is stepped up, current is stepped down, and vice versa.
+// Note that voltage transformers have efficiency losses, so the output power
+// is always less than the input power.
+message Metadata {
+  // The primary voltage of the transformer.
+  // This is the input voltage that is stepped up or down.
+  float primary = 1;
+
+  // The secondary voltage of the transformer.
+  // This is the output voltage that is the result of stepping the primary
+  // voltage up or down.
+  float secondary = 2;
+}


### PR DESCRIPTION
This commit adds the fuse component to the microgrid API. The fuse component is used to protect components from overcurrents.