### PR TITLE
Remove sensors from component category and represent the separately

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,6 +51,9 @@
 - Added fuse component. Fuses are used to protect electrical components from
   overcurrent.
 
+- Introduced a dedicated RPC method for listing sensors in the microgrid,
+  separating them from the "component" category.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -24,6 +24,7 @@ import "frequenz/api/microgrid/voltage_transformer.proto";
 import "frequenz/api/common/v1/components.proto";
 import "frequenz/api/common/v1/location.proto";
 import "frequenz/api/common/v1/metrics.proto";
+import "frequenz/api/common/v1/sensors.proto";
 
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
@@ -64,6 +65,29 @@ service Microgrid {
     };
   }
 
+  // Returns a list of sensors in the local microgrid, optionally filtered by a
+  // given list of sensor IDs and sensor categories.
+  //
+  // If provided, the filters for sensor IDs and categories have an `AND`
+  // relationship with one another, meaning that they are applied serially,
+  // but the elements within a single filter list have an `OR` relationship with
+  // each other.
+  // E.g., if `ids` = [1, 2, 3], and `categories` = [
+  //  `SensorCategory::SENSOR_CATEGORY_THERMOMETER`,
+  //  `SensorCategory::SENSOR_CATEGORY_HYGROMETER`],
+  // then the results will consist of elements that
+  // have the IDs 1, OR 2, OR 3,
+  // AND
+  // are of the categories `SensorCategory::SENSOR_CATEGORY_THERMOMETER` OR
+  // `SensorCategory::SENSOR_CATEGORY_HYGROMETER`.
+  //
+  // If a filter list is empty, then that filter is not applied.
+  rpc ListSensors(SensorFilter) returns (SensorList) {
+    option (google.api.http) = {
+      get : "/v1/sensors"
+    };
+  }
+
   // Returns a list of the connections between components as `(start, end)`
   // pairs of connection IDs, where the direction of individual connections
   // is always away from the grid endpoint, i.e. aligned with the direction
@@ -89,6 +113,13 @@ service Microgrid {
   rpc SubscribeComponentData(ComponentIdParam) returns (stream ComponentData) {
     option (google.api.http) = {
       get : "/v1/components/{id}/data"
+    };
+  }
+
+  // Returns a stream containing data from a sensor with a given ID.
+  rpc SubscribeSensorData(SensorIdParam) returns (stream SensorData) {
+    option (google.api.http) = {
+      get : "/v1/sensors/{id}/data"
     };
   }
 
@@ -371,7 +402,6 @@ message Component {
     inverter.Metadata inverter = 13;
     meter.Metadata meter = 14;
     ev_charger.Metadata ev_charger = 15;
-    sensor.Metadata sensor = 16;
     fuse.Metadata fuse = 17;
     voltage_transformer.Metadata voltage_transformer = 18;
   }
@@ -402,6 +432,51 @@ message ComponentData {
   }
 }
 
+// Parameters for filtering sensors.
+message SensorFilter {
+  // Return sensors that have the specified IDs only.
+  repeated uint64 ids = 1;
+
+  // Return sensors that have the specified categories only.
+  repeated frequenz.api.common.v1.sensors.SensorCategory categories = 2;
+}
+
+// A sensor that measures a physical metric in the microgrid's surrounding
+// environment.
+message Sensor {
+  // A unique identifier for the sensor.
+  uint64 id = 1;
+
+  // An optional name for the sensor.
+  string name = 2;
+
+  // The category of the sensor.
+  frequenz.api.common.v1.sensors.SensorCategory category = 3;
+
+  // The sensor manufacturer.
+  string manufacturer = 4;
+
+  // The model name of the sensor.
+  string model_name = 5;
+}
+
+// A message containing a list of sensors, used as a return type in certain
+// RPC methods.
+message SensorList {
+  repeated Sensor sensors = 1;
+}
+
+// Data that originates from a sensor.
+message SensorData {
+  // The timestamp of when the data was measured.
+  google.protobuf.Timestamp ts = 1;
+
+  // The sensor ID.
+  uint64 id = 2;
+
+  // The data object.
+  sensor.Sensor data = 7;
+}
 
 // Parameters for filtering the component connections
 message ConnectionFilter {
@@ -480,5 +555,11 @@ message SetBoundsParam {
 // Encapsulation of a component ID, intended to be used as a parameter for rpc
 // methods.
 message ComponentIdParam {
+  uint64 id = 1;
+}
+
+// Encapsulation of a sensor ID, intended to be used as a parameter for rpc
+// methods.
+message SensorIdParam {
   uint64 id = 1;
 }

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -346,69 +346,6 @@ message ComponentFilter {
   repeated frequenz.api.common.v1.components.ComponentCategory categories = 2;
 }
 
-// Encapsulation of a component ID, intended to be used as a parameter for rpc
-// methods.
-message ComponentIdParam {
-  uint64 id = 1;
-}
-
-// Parameters for filtering the component connections
-message ConnectionFilter {
-  // Only return connections that start from the specified component ID(s):
-  // if empty, connections with any `start` will be returned
-  repeated uint64 starts = 1;
-
-  // Only return connections that end at the specified component ID(s):
-  // if empty, connections with any `end` will be returned
-  repeated uint64 ends = 2;
-}
-
-// Parameters for setting the active power of an appropriate component using the
-// `SetPowerActive` RPC.
-message SetPowerActiveParam {
-  // The ID of the component to set the output active power of.
-  uint64 component_id = 1;
-
-  // The output active power level, in watts.
-  // -ve values are for discharging, and +ve values are for charging.
-  float power = 2;
-}
-
-// Parameters for setting the reactive power of an appropriate component using
-// the `SetPowerReactive` RPC.
-message SetPowerReactiveParam {
-  // The ID of the component to set the output reactive power of.
-  uint64 component_id = 1;
-
-  // The output reactive power level, in VAr.
-  // -ve values are for inductive (lagging) power , and +ve values are for
-  //  capacitive (leading) power.
-  float power = 2;
-}
-
-// Parameters for setting bounds of a given metric of a given component.
-message SetBoundsParam {
-  // An enumerated list of metrics whose bounds can be set.
-  enum TargetMetric {
-    TARGET_METRIC_UNSPECIFIED = 0;
-    TARGET_METRIC_POWER_ACTIVE = 1;
-    TARGET_METRIC_CURRENT = 2;
-    TARGET_METRIC_CURRENT_PHASE_1 = 3;
-    TARGET_METRIC_CURRENT_PHASE_2 = 4;
-    TARGET_METRIC_CURRENT_PHASE_3 = 5;
-    TARGET_METRIC_POWER_REACTIVE = 6;
-  }
-
-  // The ID of the target component.
-  uint64 component_id = 1;
-
-  // The target metric whose bounds have to be set.
-  TargetMetric target_metric = 2;
-
-  // The bounds for the target metric.
-  frequenz.api.common.v1.metrics.Bounds bounds = 3;
-}
-
 // A generic message for components. It is used to represent any category of
 // component, with its static parameters.
 message Component {
@@ -460,10 +397,21 @@ message ComponentData {
     inverter.Inverter inverter = 4;
     battery.Battery battery = 5;
     ev_charger.EvCharger ev_charger = 6;
-    sensor.Sensor sensor = 7;
     relay.Relay relay = 8;
     precharger.Precharger precharger = 9;
   }
+}
+
+
+// Parameters for filtering the component connections
+message ConnectionFilter {
+  // Only return connections that start from the specified component ID(s):
+  // if empty, connections with any `start` will be returned
+  repeated uint64 starts = 1;
+
+  // Only return connections that end at the specified component ID(s):
+  // if empty, connections with any `end` will be returned
+  repeated uint64 ends = 2;
 }
 
 // Describes a single connection between components of the microgrid,
@@ -482,3 +430,55 @@ message Connection {
 message ConnectionList {
   repeated Connection connections = 1;
 };
+
+// Parameters for setting the active power of an appropriate component using the
+// `SetPowerActive` RPC.
+message SetPowerActiveParam {
+  // The ID of the component to set the output active power of.
+  uint64 component_id = 1;
+
+  // The output active power level, in watts.
+  // -ve values are for discharging, and +ve values are for charging.
+  float power = 2;
+}
+
+// Parameters for setting the reactive power of an appropriate component using
+// the `SetPowerReactive` RPC.
+message SetPowerReactiveParam {
+  // The ID of the component to set the output reactive power of.
+  uint64 component_id = 1;
+
+  // The output reactive power level, in VAr.
+  // -ve values are for inductive (lagging) power , and +ve values are for
+  //  capacitive (leading) power.
+  float power = 2;
+}
+
+// Parameters for setting bounds of a given metric of a given component.
+message SetBoundsParam {
+  // An enumerated list of metrics whose bounds can be set.
+  enum TargetMetric {
+    TARGET_METRIC_UNSPECIFIED = 0;
+    TARGET_METRIC_POWER_ACTIVE = 1;
+    TARGET_METRIC_CURRENT = 2;
+    TARGET_METRIC_CURRENT_PHASE_1 = 3;
+    TARGET_METRIC_CURRENT_PHASE_2 = 4;
+    TARGET_METRIC_CURRENT_PHASE_3 = 5;
+    TARGET_METRIC_POWER_REACTIVE = 6;
+  }
+
+  // The ID of the target component.
+  uint64 component_id = 1;
+
+  // The target metric whose bounds have to be set.
+  TargetMetric target_metric = 2;
+
+  // The bounds for the target metric.
+  frequenz.api.common.v1.metrics.Bounds bounds = 3;
+}
+
+// Encapsulation of a component ID, intended to be used as a parameter for rpc
+// methods.
+message ComponentIdParam {
+  uint64 id = 1;
+}

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -34,7 +34,7 @@ import "google/protobuf/wrappers.proto";
 service Microgrid {
   /// Returns the microgrid metadata
   /// The metadata consists of information that describes the overall
-  /// microgrid, as opposed to its components,
+  /// microgrid, as opposed to its electrical components or sensors,
   /// e.g., the microgrid ID, location.
   rpc GetMicrogridMetadata(google.protobuf.Empty) returns (MicrogridMetadata) {
     option (google.api.http) = {
@@ -42,8 +42,12 @@ service Microgrid {
     };
   }
 
-  // List components in the local microgrid, optionally filtered by a given list
-  // of component IDs and component categories.
+  // List electrical components in the local microgrid, optionally filtered by a
+  // given list of component IDs and component categories.
+  //
+  // Electrical components are a part of a microgrid's electrical infrastructure
+  // are can be connected to each other to form an electrical circuit, which can
+  // then be represented as a graph.
   //
   // If provided, the filters for component IDs and categories have an `AND`
   // relationship with one another, meaning that they are applied serially,
@@ -68,6 +72,9 @@ service Microgrid {
   // Returns a list of sensors in the local microgrid, optionally filtered by a
   // given list of sensor IDs and sensor categories.
   //
+  // Sensors measure physical metrics in the microgrid's surroundings, and are
+  // not classified as electrical components.
+  //
   // If provided, the filters for sensor IDs and categories have an `AND`
   // relationship with one another, meaning that they are applied serially,
   // but the elements within a single filter list have an `OR` relationship with
@@ -88,10 +95,14 @@ service Microgrid {
     };
   }
 
-  // Returns a list of the connections between components as `(start, end)`
-  // pairs of connection IDs, where the direction of individual connections
-  // is always away from the grid endpoint, i.e. aligned with the direction
-  // of positive current according to the passive sign convention:
+  // Electrical components are a part of a microgrid's electrical infrastructure
+  // are can be connected to each other to form an electrical circuit, which can
+  // then be represented as a graph.
+  //
+  // This RPC return a list of the connections between two components, denoted
+  // by `(start, end)`. The direction of a connection is always away from the
+  // grid endpoint, i.e. aligned with the direction of positive current
+  // according to the passive sign convention:
   // https://en.wikipedia.org/wiki/Passive_sign_convention
   //
   // The request may be filtered by `start`/`end` component(s) of individual

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -363,18 +363,6 @@ message ConnectionFilter {
   repeated uint64 ends = 2;
 }
 
-// Parameters for setting the charge/discharge power of an appropriate
-// component.
-message PowerLevelParam {
-  // The ID of the component to set the output power of.
-  uint64 component_id = 1;
-
-  // The output power level, in watts. This is always a +ve integer. The sign
-  // of the power level is controlled by the implementations of the `Charge`
-  // and `Discharge` RPC methods.
-  uint64 power_w = 2;
-}
-
 // Parameters for setting the active power of an appropriate component using the
 // `SetPowerActive` RPC.
 message SetPowerActiveParam {

--- a/proto/frequenz/api/microgrid/sensor.proto
+++ b/proto/frequenz/api/microgrid/sensor.proto
@@ -14,22 +14,16 @@ import "frequenz/api/microgrid/common.proto";
 
 import "frequenz/api/common/v1/sensors.proto";
 
-// The sensor metadata.
-message Metadata {
-  // The sensor type.
-  frequenz.api.common.v1.sensors.SensorCategory type = 1;
-}
-
 // Enumerated sensor states.
-enum ComponentState {
+enum SensorState {
   // Unspecified state.
-  COMPONENT_STATE_UNSPECIFIED = 0;
+  SENSOR_STATE_UNSPECIFIED = 0;
 
   // The sensor is behaving as expected.
-  COMPONENT_STATE_OK = 1;
+  SENSOR_STATE_OK = 1;
 
   // The sensor is in an error state.
-  COMPONENT_STATE_ERROR = 2;
+  SENSOR_STATE_ERROR = 2;
 }
 
 // Enumerated sensor error codes.
@@ -41,7 +35,7 @@ enum ErrorCode {
 // State message.
 message State {
   // The state of the overall component.
-  ComponentState component_state = 1;
+  SensorState sensor_state = 1;
 }
 
 // Error message.


### PR DESCRIPTION
This update introduces a dedicated RPC method for listing sensors in the microgrid, separating them from the "component" category. This new method allows for optional sensor filtering by ID or category. The change clarifies the term "component" to exclusively refer to electrical equipment like inverters and batteries, while sensors are now treated as a distinct entity.