### PR TITLE
Rename RPC parameters to be more consistent with the RPC names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -54,6 +54,9 @@
 - Introduced a dedicated RPC method for listing sensors in the microgrid,
   separating them from the "component" category.
 
+- The RPC parameters have been renamed to be more consistent with the RPC names,
+  and with each other.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/microgrid/microgrid.proto
+++ b/proto/frequenz/api/microgrid/microgrid.proto
@@ -63,7 +63,7 @@ service Microgrid {
   // `ComponentCategory::COMPONENT_CATEGORY_BATTERY`.
   //
   // If a filter list is empty, then that filter is not applied.
-  rpc ListComponents(ComponentFilter) returns (ComponentList) {
+  rpc ListComponents(ListComponentsRequest) returns (ListComponentsResponse) {
     option (google.api.http) = {
       get : "/v1/components"
     };
@@ -89,7 +89,7 @@ service Microgrid {
   // `SensorCategory::SENSOR_CATEGORY_HYGROMETER`.
   //
   // If a filter list is empty, then that filter is not applied.
-  rpc ListSensors(SensorFilter) returns (SensorList) {
+  rpc ListSensors(ListSensorRequest) returns (ListSensorsResponse) {
     option (google.api.http) = {
       get : "/v1/sensors"
     };
@@ -114,21 +114,24 @@ service Microgrid {
   // * each `start` component ID is either `1`, `2`, OR `3`,
   //  AND
   // * each `end` component ID is either `4`, `5`, OR `6`.
-  rpc ListConnections(ConnectionFilter) returns (ConnectionList) {
+  rpc ListConnections(ListConnectionsRequest)
+    returns (ListConnectionsResponse) {
     option (google.api.http) = {
       get : "/v1/connections"
     };
   }
 
   // Returns a stream containing data from a component with a given ID.
-  rpc SubscribeComponentData(ComponentIdParam) returns (stream ComponentData) {
+  rpc SubscribeComponentData(SubscribeComponentDataRequest)
+    returns (stream ComponentData) {
     option (google.api.http) = {
       get : "/v1/components/{id}/data"
     };
   }
 
   // Returns a stream containing data from a sensor with a given ID.
-  rpc SubscribeSensorData(SensorIdParam) returns (stream SensorData) {
+  rpc SubscribeSensorData(SubscribeSensorDataRequest)
+    returns (stream SensorData) {
     option (google.api.http) = {
       get : "/v1/sensors/{id}/data"
     };
@@ -180,8 +183,8 @@ service Microgrid {
   // ```
   // ---- values here are disallowed and wil be rejected
   // ==== vales here are allowed and will be accepted
-  rpc AddComponentExclusionBounds(SetBoundsParam)
-    returns (google.protobuf.Timestamp);
+  rpc AddComponentExclusionBounds(AddComponentExclusionBoundsRequest)
+    returns (AddComponentExclusionBoundsResponse);
 
   // Adds inclusion bounds for a given metric of a given component, and returns
   // the UTC timestamp until which the given inclusion bounds will stay in
@@ -218,8 +221,8 @@ service Microgrid {
   // ```
   // ---- values here are disallowed and wil be rejected
   // ==== vales here are allowed and will be accepted
-  rpc AddComponentInclusionBounds(SetBoundsParam)
-    returns (google.protobuf.Timestamp);
+  rpc AddComponentInclusionBounds(AddComponentInclusionBoundsRequest)
+    returns (AddComponentInclusionBoundsResponse);
 
   // Sets the active power output of a component with a given ID, provided the
   // component supports it.
@@ -234,7 +237,7 @@ service Microgrid {
   //
   // * Inverter: Sends the discharge command to the inverter, making it deliver
   //  AC power.
-  rpc SetComponentPowerActive(SetPowerActiveParam)
+  rpc SetComponentPowerActive(SetComponentPowerActiveRequest)
     returns (google.protobuf.Empty) {
     option (google.api.http) = {
       get : "/v1/components/{component_id}/setPowerActive/{power}"
@@ -248,7 +251,7 @@ service Microgrid {
   // E.g., an inverter may have a resolution of 88 VAr.
   // In such cases, the magnitude of power will be floored to the nearest
   // multiple of the resolution.
-  rpc SetComponentPowerReactive(SetPowerReactiveParam)
+  rpc SetComponentPowerReactive(SetComponentPowerReactiveRequest)
     returns (google.protobuf.Empty) {
     option (google.api.http) = {
       get : "/v1/components/{component_id}/setPowerReactive/{power}"
@@ -280,7 +283,7 @@ service Microgrid {
   //
   // If a feature required to perform an action is missing, then that action is
   // skipped.
-  rpc StartComponent(ComponentIdParam) returns (google.protobuf.Empty) {
+  rpc StartComponent(StartComponentRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       get : "/v1/components/{id}/start"
     };
@@ -300,7 +303,8 @@ service Microgrid {
   //
   // If any of the above mentioned actions for a given component has already
   // been performed, then this method call effectively skips that action.
-  rpc HotStandbyComponent(ComponentIdParam) returns (google.protobuf.Empty) {
+  rpc HotStandbyComponent(HotStandbyComponentRequest)
+    returns (google.protobuf.Empty) {
     option (google.api.http) = {
       get : "/v1/components/{id}/hotStandby"
     };
@@ -321,7 +325,8 @@ service Microgrid {
   //
   // If any of the above mentioned actions for a given component has already
   // been performed, then this method call efffectively skips that action.
-  rpc ColdStandbyComponent(ComponentIdParam) returns (google.protobuf.Empty) {
+  rpc ColdStandbyComponent(ColdStandbyComponentRequest)
+    returns (google.protobuf.Empty) {
     option (google.api.http) = {
       get : "/v1/components/{id}/coldStandby"
     };
@@ -354,7 +359,7 @@ service Microgrid {
   //
   // If a feature required to perform an action is missing, then that action is
   // skipped.
-  rpc StopComponent(ComponentIdParam) returns (google.protobuf.Empty) {
+  rpc StopComponent(StopComponentRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       get : "/v1/components/{id}/stop"
     };
@@ -362,7 +367,8 @@ service Microgrid {
 
   // Acknowledges any recoverable error reported by the component, and brings it
   // back to the stopped or cold-standby state.
-  rpc AckComponentError(ComponentIdParam) returns (google.protobuf.Empty) {
+  rpc AckComponentError(AckComponentErrorRequest)
+    returns (google.protobuf.Empty) {
     option (google.api.http) = {
       get : "/v1/components/{id}/errorAck"
     };
@@ -379,25 +385,25 @@ message MicrogridMetadata {
   frequenz.api.common.v1.location.Location location = 2;
 }
 
-// Parameters for filtering the components.
-message ComponentFilter {
+// Request parameters for the RPC `ListComponents`.
+// Contains filtering parameters for listing components.
+message ListComponentsRequest {
   // Return components that have the specified IDs only.
-  repeated uint64 ids = 1;
+  repeated uint64 component_ids = 1;
 
   // Return components that have the specified categories only.
   repeated frequenz.api.common.v1.components.ComponentCategory categories = 2;
 }
 
-// A generic message for components. It is used to represent any category of
-// component, with its static parameters.
+// A message containing the metadata for a component.
 message Component {
-  // A unique identifier for the component.
+  // The component ID.
   uint64 id = 1;
 
-  // An optional name for the component.
+  // The component name.
   string name = 2;
 
-  // The category of the component.
+  // The component category. E.g., Inverter, Battery, etc.
   frequenz.api.common.v1.components.ComponentCategory category = 3;
 
   // The component manufacturer.
@@ -418,35 +424,17 @@ message Component {
   }
 }
 
-// A message containing a list of components, used as a return typ in certain
-// RPC methods.
-message ComponentList {
+// A message containing a list of components.
+// Used as the return type in the RPC `ListComponents`.
+message ListComponentsResponse {
   repeated Component components = 1;
 }
 
-// A generic container for data that can originate from any component type.
-message ComponentData {
-  // The timestamp of when the data was measured.
-  google.protobuf.Timestamp ts = 1;
-
-  // The component ID.
-  uint64 id = 2;
-
-  // The data object.
-  oneof data {
-    meter.Meter meter = 3;
-    inverter.Inverter inverter = 4;
-    battery.Battery battery = 5;
-    ev_charger.EvCharger ev_charger = 6;
-    relay.Relay relay = 8;
-    precharger.Precharger precharger = 9;
-  }
-}
-
-// Parameters for filtering sensors.
-message SensorFilter {
+// Request parameters for the RPC `ListSensors`.
+// Contains filtering parameters for listing sensors.
+message ListSensorRequest {
   // Return sensors that have the specified IDs only.
-  repeated uint64 ids = 1;
+  repeated uint64 sensor_ids = 1;
 
   // Return sensors that have the specified categories only.
   repeated frequenz.api.common.v1.sensors.SensorCategory categories = 2;
@@ -471,26 +459,15 @@ message Sensor {
   string model_name = 5;
 }
 
-// A message containing a list of sensors, used as a return type in certain
-// RPC methods.
-message SensorList {
+// Response message for the RPC `ListSensors`.
+// A message containing a list of sensors.
+message ListSensorsResponse {
   repeated Sensor sensors = 1;
 }
 
-// Data that originates from a sensor.
-message SensorData {
-  // The timestamp of when the data was measured.
-  google.protobuf.Timestamp ts = 1;
-
-  // The sensor ID.
-  uint64 id = 2;
-
-  // The data object.
-  sensor.Sensor data = 7;
-}
-
-// Parameters for filtering the component connections
-message ConnectionFilter {
+// Request parameters for the RPC `ListConnections`.
+// Contains filtering parameters for listing connections.
+message ListConnectionsRequest {
   // Only return connections that start from the specified component ID(s):
   // if empty, connections with any `start` will be returned
   repeated uint64 starts = 1;
@@ -512,14 +489,108 @@ message Connection {
   uint64 end = 2;
 }
 
-// List of connections between components
-message ConnectionList {
+// Response message for the RPC `ListConnections`.
+// Contains a list of connections.
+message ListConnectionsResponse {
+  // The list of connections.
   repeated Connection connections = 1;
 };
 
-// Parameters for setting the active power of an appropriate component using the
-// `SetPowerActive` RPC.
-message SetPowerActiveParam {
+// Request parameters for the RPC `SubscribeComponentData`.
+message SubscribeComponentDataRequest {
+  // The component ID to subscribe to.
+  uint64 component_id = 1;
+}
+
+// A data sample from a component in the microgrid.
+// Components belonging to all categories and types can be represented using
+// this message.
+message ComponentData {
+  // The timestamp of when the data was measured.
+  google.protobuf.Timestamp ts = 1;
+
+  // The component ID.
+  uint64 id = 2;
+
+  // The data object.
+  oneof data {
+    meter.Meter meter = 3;
+    inverter.Inverter inverter = 4;
+    battery.Battery battery = 5;
+    ev_charger.EvCharger ev_charger = 6;
+    relay.Relay relay = 8;
+    precharger.Precharger precharger = 9;
+  }
+}
+
+// Request parameters for the RPC `SubscribeSensorData`.
+message SubscribeSensorDataRequest {
+  // The sensor ID to subscribe to.
+  uint64 sensor_id = 1;
+}
+
+// A data sample from a sensor in the microgrid.
+message SensorData {
+  // The timestamp of when the data was measured.
+  google.protobuf.Timestamp ts = 1;
+
+  // The sensor ID.
+  uint64 id = 2;
+
+  // The data object.
+  sensor.Sensor data = 7;
+}
+
+// An enumerated list of metrics whose bounds can be set using the RPCs
+// `AddComponentExclusionBounds` and `AddComponentInclusionBounds`.
+enum ComponentBoundsTargetMetric {
+  COMPONENT_BOUNDS_TARGET_METRIC_UNSPECIFIED = 0;
+  COMPONENT_BOUNDS_TARGET_METRIC_POWER_ACTIVE = 1;
+  COMPONENT_BOUNDS_TARGET_METRIC_CURRENT = 2;
+  COMPONENT_BOUNDS_TARGET_METRIC_CURRENT_PHASE_1 = 3;
+  COMPONENT_BOUNDS_TARGET_METRIC_CURRENT_PHASE_2 = 4;
+  COMPONENT_BOUNDS_TARGET_METRIC_CURRENT_PHASE_3 = 5;
+  COMPONENT_BOUNDS_TARGET_METRIC_POWER_REACTIVE = 6;
+}
+
+// Request parameters for the RPC `AddComponentExclusionBounds`.
+message AddComponentExclusionBoundsRequest {
+  // The ID of the target component.
+  uint64 component_id = 1;
+
+  // The target metric whose bounds have to be set.
+  ComponentBoundsTargetMetric target_metric = 2;
+
+  // The bounds for the target metric.
+  frequenz.api.common.v1.metrics.Bounds bounds = 3;
+}
+
+// Response message for the RPC `AddComponentExclusionBounds`.
+message AddComponentExclusionBoundsResponse {
+  // The timestamp until which the given exclusion bounds will stay in effect.
+  google.protobuf.Timestamp ts = 1;
+}
+
+// Request parameters for the RPC `AddComponentInclusionBounds`.
+message AddComponentInclusionBoundsRequest {
+  // The ID of the target component.
+  uint64 component_id = 1;
+
+  // The target metric whose bounds have to be set.
+  ComponentBoundsTargetMetric target_metric = 2;
+
+  // The bounds for the target metric.
+  frequenz.api.common.v1.metrics.Bounds bounds = 3;
+}
+
+// Response message for the RPC `AddComponentInclusionBounds`.
+message AddComponentInclusionBoundsResponse {
+  // The timestamp until which the given inclusion bounds will stay in effect.
+  google.protobuf.Timestamp ts = 1;
+}
+
+// Request parameters for the RPC `SetComponentPowerActive`.
+message SetComponentPowerActiveRequest {
   // The ID of the component to set the output active power of.
   uint64 component_id = 1;
 
@@ -528,9 +599,8 @@ message SetPowerActiveParam {
   float power = 2;
 }
 
-// Parameters for setting the reactive power of an appropriate component using
-// the `SetPowerReactive` RPC.
-message SetPowerReactiveParam {
+// Request parameters for the RPC `SetComponentPowerReactive`.
+message SetComponentPowerReactiveRequest {
   // The ID of the component to set the output reactive power of.
   uint64 component_id = 1;
 
@@ -540,37 +610,32 @@ message SetPowerReactiveParam {
   float power = 2;
 }
 
-// Parameters for setting bounds of a given metric of a given component.
-message SetBoundsParam {
-  // An enumerated list of metrics whose bounds can be set.
-  enum TargetMetric {
-    TARGET_METRIC_UNSPECIFIED = 0;
-    TARGET_METRIC_POWER_ACTIVE = 1;
-    TARGET_METRIC_CURRENT = 2;
-    TARGET_METRIC_CURRENT_PHASE_1 = 3;
-    TARGET_METRIC_CURRENT_PHASE_2 = 4;
-    TARGET_METRIC_CURRENT_PHASE_3 = 5;
-    TARGET_METRIC_POWER_REACTIVE = 6;
-  }
-
-  // The ID of the target component.
+// Request parameters for the RPC `StartComponent`.
+message StartComponentRequest {
+  // The component ID to start.
   uint64 component_id = 1;
-
-  // The target metric whose bounds have to be set.
-  TargetMetric target_metric = 2;
-
-  // The bounds for the target metric.
-  frequenz.api.common.v1.metrics.Bounds bounds = 3;
 }
 
-// Encapsulation of a component ID, intended to be used as a parameter for rpc
-// methods.
-message ComponentIdParam {
-  uint64 id = 1;
+// Request parameters for the RPC `HotStandbyComponent`.
+message HotStandbyComponentRequest {
+  // The component ID to set to hot-standby.
+  uint64 component_id = 1;
 }
 
-// Encapsulation of a sensor ID, intended to be used as a parameter for rpc
-// methods.
-message SensorIdParam {
-  uint64 id = 1;
+// Request parameters for the RPC `ColdStandbyComponent`.
+message ColdStandbyComponentRequest {
+  // The component ID to set to cold-standby.
+  uint64 component_id = 1;
+}
+
+// Request parameters for the RPC `StopComponent`.
+message StopComponentRequest {
+  // The component ID to stop.
+  uint64 component_id = 1;
+}
+
+// Request parameters for the RPC `AckComponentError`.
+message AckComponentErrorRequest {
+  // The component ID to acknowledge the error for.
+  uint64 component_id = 1;
 }


### PR DESCRIPTION
The RPC parameters were named in a way that was not consistent with the RPC names. This commit renames the RPC parameters to be more consistent with the RPC names. The following rules have been followed, in order:
1. If an RPC is named `GetX`, then its request message is named `GetXRequest` and its response message is named `X`. Same for `SubscribeX`.
2. If an RPC is named `VerbX`, then its request message is named `VerbXRequest`. Its response message is named `VerbXResponse`, unless the response type is `google.protobuf.Empty`.

Also, the documentation in the proto files has been updated to be more consistent with each other.