### PR TITLE
Add major version to package names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -57,6 +57,10 @@
 - The RPC parameters have been renamed to be more consistent with the RPC names,
   and with each other.
 
+- The package names have been changed from `frequenz.api.microgrid.<package>` to
+  `frequenz.api.microgrid.v1.<package>`. `v1` is the API's major version, and
+  will be incremented for breaking changes.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/microgrid/v1/battery.proto
+++ b/proto/frequenz/api/microgrid/v1/battery.proto
@@ -8,9 +8,9 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.battery;
+package frequenz.api.microgrid.v1.battery;
 
-import "frequenz/api/microgrid/common.proto";
+import "frequenz/api/microgrid/v1/common.proto";
 
 import "frequenz/api/common/v1/components.proto";
 import "frequenz/api/common/v1/metrics.proto";

--- a/proto/frequenz/api/microgrid/v1/common.proto
+++ b/proto/frequenz/api/microgrid/v1/common.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.common;
+package frequenz.api.microgrid.v1.common;
 
 // Error levels definitions.
 enum ErrorLevel {

--- a/proto/frequenz/api/microgrid/v1/ev_charger.proto
+++ b/proto/frequenz/api/microgrid/v1/ev_charger.proto
@@ -8,9 +8,9 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.ev_charger;
+package frequenz.api.microgrid.v1.ev_charger;
 
-import "frequenz/api/microgrid/common.proto";
+import "frequenz/api/microgrid/v1/common.proto";
 
 import "frequenz/api/common/v1/components.proto";
 import "frequenz/api/common/v1/metrics.proto";

--- a/proto/frequenz/api/microgrid/v1/fuse.proto
+++ b/proto/frequenz/api/microgrid/v1/fuse.proto
@@ -11,7 +11,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.fuse;
+package frequenz.api.microgrid.v1.fuse;
 
 // The fuse component represents a fuse in the microgrid. It is used to protect
 // components from overcurrents.

--- a/proto/frequenz/api/microgrid/v1/grid.proto
+++ b/proto/frequenz/api/microgrid/v1/grid.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.grid;
+package frequenz.api.microgrid.v1.grid;
 
 // The grid connection point metadata.
 message Metadata {

--- a/proto/frequenz/api/microgrid/v1/inverter.proto
+++ b/proto/frequenz/api/microgrid/v1/inverter.proto
@@ -8,9 +8,9 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.inverter;
+package frequenz.api.microgrid.v1.inverter;
 
-import "frequenz/api/microgrid/common.proto";
+import "frequenz/api/microgrid/v1/common.proto";
 
 import "frequenz/api/common/v1/components.proto";
 import "frequenz/api/common/v1/metrics.proto";

--- a/proto/frequenz/api/microgrid/v1/meter.proto
+++ b/proto/frequenz/api/microgrid/v1/meter.proto
@@ -8,9 +8,9 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.meter;
+package frequenz.api.microgrid.v1.meter;
 
-import "frequenz/api/microgrid/common.proto";
+import "frequenz/api/microgrid/v1/common.proto";
 
 import "frequenz/api/common/v1/metrics/electrical.proto";
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -8,18 +8,18 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid;
+package frequenz.api.microgrid.v1;
 
-import "frequenz/api/microgrid/battery.proto";
-import "frequenz/api/microgrid/ev_charger.proto";
-import "frequenz/api/microgrid/fuse.proto";
-import "frequenz/api/microgrid/grid.proto";
-import "frequenz/api/microgrid/inverter.proto";
-import "frequenz/api/microgrid/meter.proto";
-import "frequenz/api/microgrid/precharger.proto";
-import "frequenz/api/microgrid/relay.proto";
-import "frequenz/api/microgrid/sensor.proto";
-import "frequenz/api/microgrid/voltage_transformer.proto";
+import "frequenz/api/microgrid/v1/battery.proto";
+import "frequenz/api/microgrid/v1/ev_charger.proto";
+import "frequenz/api/microgrid/v1/fuse.proto";
+import "frequenz/api/microgrid/v1/grid.proto";
+import "frequenz/api/microgrid/v1/inverter.proto";
+import "frequenz/api/microgrid/v1/meter.proto";
+import "frequenz/api/microgrid/v1/precharger.proto";
+import "frequenz/api/microgrid/v1/relay.proto";
+import "frequenz/api/microgrid/v1/sensor.proto";
+import "frequenz/api/microgrid/v1/voltage_transformer.proto";
 
 import "frequenz/api/common/v1/components.proto";
 import "frequenz/api/common/v1/location.proto";

--- a/proto/frequenz/api/microgrid/v1/precharger.proto
+++ b/proto/frequenz/api/microgrid/v1/precharger.proto
@@ -15,9 +15,9 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.precharger;
+package frequenz.api.microgrid.v1.precharger;
 
-import "frequenz/api/microgrid/common.proto";
+import "frequenz/api/microgrid/v1/common.proto";
 
 
 // Enumerated meter states.

--- a/proto/frequenz/api/microgrid/v1/relay.proto
+++ b/proto/frequenz/api/microgrid/v1/relay.proto
@@ -11,9 +11,9 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.relay;
+package frequenz.api.microgrid.v1.relay;
 
-import "frequenz/api/microgrid/common.proto";
+import "frequenz/api/microgrid/v1/common.proto";
 
 
 // Enumerated relay states.

--- a/proto/frequenz/api/microgrid/v1/sensor.proto
+++ b/proto/frequenz/api/microgrid/v1/sensor.proto
@@ -8,9 +8,9 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.sensor;
+package frequenz.api.microgrid.v1.sensor;
 
-import "frequenz/api/microgrid/common.proto";
+import "frequenz/api/microgrid/v1/common.proto";
 
 import "frequenz/api/common/v1/sensors.proto";
 

--- a/proto/frequenz/api/microgrid/v1/voltage_transformer.proto
+++ b/proto/frequenz/api/microgrid/v1/voltage_transformer.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package frequenz.api.microgrid.voltage_transformer;
+package frequenz.api.microgrid.v1.voltage_transformer;
 
 // A voltage transformer.
 // Voltage transformers are used to step up or step down the voltage, keeping

--- a/py/frequenz/api/microgrid/v1/__init__.py
+++ b/py/frequenz/api/microgrid/v1/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Frequenz gRPC API for monitoring and control of microgrids."""

--- a/pytests/test_microgrid.py
+++ b/pytests/test_microgrid.py
@@ -8,16 +8,17 @@
 
 def test_package_import() -> None:
     """Test if the microgrid package can be imported."""
-    from frequenz.api import microgrid
+    from frequenz.api.microgrid import v1
 
-    assert microgrid is not None
+    assert v1 is not None
 
 
 def test_module_import() -> None:
     """Test if the microgrid_pb2 package can be imported."""
-    from frequenz.api.microgrid import microgrid_pb2
+    from frequenz.api.microgrid.v1 import microgrid_pb2
 
     assert microgrid_pb2 is not None
-    from frequenz.api.microgrid import microgrid_pb2_grpc
+
+    from frequenz.api.microgrid.v1 import microgrid_pb2_grpc
 
     assert microgrid_pb2_grpc is not None


### PR DESCRIPTION
The package names have been changed from
`frequenz.api.microgrid.<package>` to
`frequenz.api.microgrid.v1.<package>`. `v1` is the API's major version, and will be incremented for breaking changes.