### PR TITLE
Change RPCs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,7 +16,7 @@
   message from the common API also has a `country_code` member.
 
 - The following gRPC methods have been renamed:
-  `StreamComponentData` -> `SubscribeComponentData`
+  `StreamComponentData` -> `ReceiveComponentDataStream`
   `AddExclusionBounds`  -> `AddComponentExclusionBounds`
   `AddInclusionBounds`  -> `AddComponentInclusionBounds`
   `SetPowerActive`      -> `SetComponentPowerActive`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,8 @@
   `Stop`                -> `StopComponent`
   `ErrorAck`            -> `AckComponentError`
 
+- The following gRPC method have been removed: `HotStandby`
+
 - Added support for a new Component category: Relays. These are electromagnetic
   switches that control circuit breakers in the microgrid, e.g., to connect or
   disconnect an inverter from the grid. Relays support the following methods:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,7 +23,7 @@
   `SetPowerReactive`    -> `SetComponentPowerReactive`
   `Start`               -> `StartComponent`
   `HotStandby`          -> `HotStandbyComponent`
-  `ColdStandby`         -> `ColdStandbyComponent`
+  `ColdStandby`         -> `PutComponentInStandby`
   `Stop`                -> `StopComponent`
   `ErrorAck`            -> `AckComponentError`
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -289,27 +289,6 @@ service Microgrid {
     };
   }
 
-  // Sets the given component into a hot-standby state, from which it can return
-  // into an operational state within at most 5 seconds.
-  //
-  // Performs the following sequence actions for the following component
-  // categories:
-  //
-  // * Inverter: Checks if AC and DC relays are closed, then
-  //  * sets power to 0
-  //
-  // If any of the checks mentioned above fails, then the method call returns an
-  // error.
-  //
-  // If any of the above mentioned actions for a given component has already
-  // been performed, then this method call effectively skips that action.
-  rpc HotStandbyComponent(HotStandbyComponentRequest)
-    returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      get : "/v1/components/{id}/hotStandby"
-    };
-  }
-
   // Sets the given component into a standby state, from which it can take a
   // few minutes to return to an operational state. A transition to an
   // operational state can be triggered by calling the `StartComponent` RPC, or
@@ -615,12 +594,6 @@ message SetComponentPowerReactiveRequest {
 // Request parameters for the RPC `StartComponent`.
 message StartComponentRequest {
   // The component ID to start.
-  uint64 component_id = 1;
-}
-
-// Request parameters for the RPC `HotStandbyComponent`.
-message HotStandbyComponentRequest {
-  // The component ID to set to hot-standby.
   uint64 component_id = 1;
 }
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -130,7 +130,7 @@ service Microgrid {
   }
 
   // Returns a stream containing data from a sensor with a given ID.
-  rpc SubscribeSensorData(SubscribeSensorDataRequest)
+  rpc ReceiveSensorDataStream(ReceiveSensorDataStreamRequest)
     returns (stream SensorData) {
     option (google.api.http) = {
       get : "/v1/sensors/{id}/data"
@@ -504,8 +504,8 @@ message ComponentData {
   }
 }
 
-// Request parameters for the RPC `SubscribeSensorData`.
-message SubscribeSensorDataRequest {
+// Request parameters for the RPC `ReceiveSensorDataStream`.
+message ReceiveSensorDataStreamRequest {
   // The sensor ID to subscribe to.
   uint64 sensor_id = 1;
 }

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -310,8 +310,10 @@ service Microgrid {
     };
   }
 
-  // Sets the given component into a cold-standby state, from which it can
-  // return into an operational state within at most 2 minutes.
+  // Sets the given component into a standby state, from which it can take a
+  // few minutes to return to an operational state. A transition to an
+  // operational state can be triggered by calling the `StartComponent` RPC, or
+  // the `SetComponentPowerActive` RPC.
   //
   // Performs the following sequence actions for the following component
   // categories:
@@ -325,10 +327,10 @@ service Microgrid {
   //
   // If any of the above mentioned actions for a given component has already
   // been performed, then this method call efffectively skips that action.
-  rpc ColdStandbyComponent(ColdStandbyComponentRequest)
+  rpc PutComponentInStandby(PutComponentInStandbyRequest)
     returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      get : "/v1/components/{id}/coldStandby"
+      get : "/v1/components/{id}/standby"
     };
   }
 
@@ -622,9 +624,9 @@ message HotStandbyComponentRequest {
   uint64 component_id = 1;
 }
 
-// Request parameters for the RPC `ColdStandbyComponent`.
-message ColdStandbyComponentRequest {
-  // The component ID to set to cold-standby.
+// Request parameters for the RPC `PutComponentInStandby`.
+message PutComponentInStandbyRequest {
+  // The component ID to set to standby.
   uint64 component_id = 1;
 }
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -122,7 +122,7 @@ service Microgrid {
   }
 
   // Returns a stream containing data from a component with a given ID.
-  rpc SubscribeComponentData(SubscribeComponentDataRequest)
+  rpc ReceiveComponentDataStream(ReceiveComponentDataStreamRequest)
     returns (stream ComponentData) {
     option (google.api.http) = {
       get : "/v1/components/{id}/data"
@@ -477,8 +477,8 @@ message ListConnectionsResponse {
   repeated Connection connections = 1;
 };
 
-// Request parameters for the RPC `SubscribeComponentData`.
-message SubscribeComponentDataRequest {
+// Request parameters for the RPC `ReceiveComponentDataStream`.
+message ReceiveComponentDataStreamRequest {
   // The component ID to subscribe to.
   uint64 component_id = 1;
 }


### PR DESCRIPTION
This PR includes the following changes:

* Remove RPC `HotStandby`
* Rename RPC `ColdStandby` to `Standby`
* Rename RPC `SubscribeComponentData` to `ReceiveComponentDataStream`
* Rename RPC `SubscribeSensorData` to `ReceiveSensorDataStream`