### PR TITLE
Return valid-until timestamps from set-power RPCs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,6 +48,12 @@
   If this list is empty, then no data will be streamed, and the service will
   return an error.
 
+- The RPC `SetComponentPowerActive`now returns a timestamp until which the
+  command will stay in effect. The component's active power will be set to 0
+  after this timestamp, if the API receives no further requests to change it
+  before then. By default, this timestamp will be the current time plus 60
+  seconds.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -54,6 +54,12 @@
   before then. By default, this timestamp will be the current time plus 60
   seconds.
 
+- The RPC `SetComponentPowerReactive`now returns a timestamp until which the
+  command will stay in effect. The component's reactive power will be set to 0
+  after this timestamp, if the API receives no further requests to change it
+  before then. By default, this timestamp will be the current time plus 60
+  seconds.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -220,7 +220,15 @@ service Microgrid {
     returns (AddComponentInclusionBoundsResponse);
 
   // Sets the active power output of a component with a given ID, provided the
-  // component supports it.
+  // component supports it. The power output is specified in watts.
+  //
+  // The power output can be -ve or +ve, depending on whether the component is
+  // supposed to be discharging or charging, respectively.
+  //
+  // The return value is the timestamp until which the given power command will
+  // stay in effect. After this timestamp, the component's active power will be
+  // set to 0, if the API receives no further command to change it before then.
+  // By default, this timestamp will be set to the current time plus 60 seconds.
   //
   // Note that the target component may have a resolution of more than 1 W.
   // E.g., an inverter may have a resolution of 88 W.
@@ -233,7 +241,7 @@ service Microgrid {
   // * Inverter: Sends the discharge command to the inverter, making it deliver
   //  AC power.
   rpc SetComponentPowerActive(SetComponentPowerActiveRequest)
-    returns (google.protobuf.Empty) {
+    returns (SetComponentPowerActiveResponse) {
     option (google.api.http) = {
       get : "/v1/components/{component_id}/setPowerActive/{power}"
     };
@@ -536,6 +544,15 @@ message SetComponentPowerActiveRequest {
   // The output active power level, in watts.
   // -ve values are for discharging, and +ve values are for charging.
   float power = 2;
+}
+
+// Response message for the RPC `SetComponentPowerActive`.
+message SetComponentPowerActiveResponse {
+  // The timestamp until which the given power command will stay in effect.
+  // After this timestamp, the component power will be set to 0, if the API
+  // receives no further power commands. By default, this timestamp will be set
+  // to the current time plus 60 seconds.
+  google.protobuf.Timestamp valid_until = 1;
 }
 
 // Request parameters for the RPC `SetComponentPowerReactive`.

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -248,14 +248,23 @@ service Microgrid {
   }
 
   // Sets the reactive power output of a component with a given ID, provided the
-  // component supports it.
+  // component supports it. The power output is specified in VAr.
+  //
+  // The power output can be -ve or +ve, depending on whether the component is
+  // supposed to be delivering inductive or capacitive power, respectively.
+  //
+  // The return value is the timestamp until which the given power command will
+  // stay in effect. After this timestamp, the component's reactive power will
+  // be set to 0, if the API receives no further command to change it before
+  // then.
+  // By default, this timestamp will be set to the current time plus 60 seconds.
   //
   // Note that the target component may have a resolution of more than 1 VAr.
   // E.g., an inverter may have a resolution of 88 VAr.
   // In such cases, the magnitude of power will be floored to the nearest
   // multiple of the resolution.
   rpc SetComponentPowerReactive(SetComponentPowerReactiveRequest)
-    returns (google.protobuf.Empty) {
+    returns (SetComponentPowerReactiveResponse) {
     option (google.api.http) = {
       get : "/v1/components/{component_id}/setPowerReactive/{power}"
     };
@@ -564,6 +573,15 @@ message SetComponentPowerReactiveRequest {
   // -ve values are for inductive (lagging) power , and +ve values are for
   //  capacitive (leading) power.
   float power = 2;
+}
+
+// Response message for the RPC `SetComponentPowerReactive`.
+message SetComponentPowerReactiveResponse {
+  // The timestamp until which the given power command will stay in effect.
+  // After this timestamp, the component power will be set to 0, if the API
+  // receives no further power commands. By default, this timestamp will be set
+  // to the current time plus 60 seconds.
+  google.protobuf.Timestamp valid_until = 1;
 }
 
 // Request parameters for the RPC `StartComponent`.


### PR DESCRIPTION
The RPCs to set power now return timestamps until which the command will stay in effect. The component's active/reactive power will be set to 0 after this timestamp, if the API receives no further requests to change it before then.

By default, this timestamp will be the current time plus 60 seconds.