### PR TITLE
Bump the api-common dependency to v0.5.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,8 @@
 
 ## Summary
 
-This release doesn't introduce any visible changes, it's done mainly to be able to build the new [documentation website](https://frequenz-floss.github.io/frequenz-api-microgrid/).
+This release bumps the `frequenz-api-common` dependency to v0.5.3, allowing downstream projects to use a newer `frequenz-api-common` version too.
+
+Please note that the googleapis-common-protos dependency is also bumped to v1.56.4, which is the version that api-common v0.5.4 depends on.
+    
+Strictly speaking, this is a breaking change, as you might need to bump your googleapis-common-protos dependency to v1.56.4 too if it is specified explicitly, but this is highly unlikely to happen and very easy to fix.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,7 @@ plugins:
           import:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
-            - https://frequenz-floss.github.io/frequenz-api-common/v0.3/objects.inv
+            - https://frequenz-floss.github.io/frequenz-api-common/v0.5/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.3.0, < 0.4",
-  "googleapis-common-protos >= 1.56.2, < 2",
+  "frequenz-api-common >= 0.5.4, < 0.6",
+  "googleapis-common-protos >= 1.56.4, < 2",
   "grpcio >= 1.51.1, < 2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
The new v0.5.4 release of the api-common repository is now backwards compatible with the old v0.3.x releases. We bump the dependency so microgrid API can be used together with other APIs that depend on the newer common API version.

Please note that the googleapis-common-protos dependency is also bumped to v1.56.4, which is the version that api-common v0.5.4 depends on.

Strictly speaking, this is a breaking change too, as projects might need to bump their googleapis-common-protos dependency to v1.56.4 too if they specify it explicitly, but this is highly unlikely and very easy to fix.
