### PR TITLE
Support repo-config v0.9 properly

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,34 +7,44 @@
 # https://github.com/marketplace/actions/labeler
 
 "part:docs":
-  - "**/*.md"
-  - "docs/**"
-  - "examples/**"
-  - LICENSE
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/*.md"
+      - "docs/**"
+      - "examples/**"
+      - LICENSE
 
 "part:tests":
-  - "**/conftest.py"
-  - "pytests/**"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/conftest.py"
+      - "pytests/**"
 
 "part:tooling":
-  - "**/*.ini"
-  - "**/*.toml"
-  - "**/*.yaml"
-  - "**/*.yml"
-  - "**/conftest.py"
-  - ".editorconfig"
-  - ".git*"
-  - ".git*/**"
-  - "docs/*.py"
-  - CODEOWNERS
-  - MANIFEST.in
-  - noxfile.py
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/*.ini"
+      - "**/*.toml"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - "**/conftest.py"
+      - ".editorconfig"
+      - ".git*"
+      - ".git*/**"
+      - "docs/*.py"
+      - CODEOWNERS
+      - MANIFEST.in
+      - noxfile.py
 
 "part:python":
-  - "py/**"
-  - "pytests/**"
-  - "**/*.py"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "py/**"
+      - "pytests/**"
+      - "**/*.py"
 
 "part:protobuf":
-  - "proto/**"
-  - "**/*.proto"
+  - changed-files:
+    - any-glob-to-any-file:
+      - "proto/**"
+      - "**/*.proto"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@ jobs:
         # only use hashes to pick the action to execute (instead of tags or branches).
         # For more details read:
         # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-        uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594  # 4.3.0
+        uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           dot: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ git checkout v${ver}
 cd -
 
 sed s/"frequenz-api-common == [0-9]\.[0-9]\.[0-9]"/"frequenz-api-common == ${ver}"/g -i pyproject.toml
+sed 's|https://frequenz-floss.github.io/frequenz-api-common/v[0-9].[0-9]/objects.inv|https://frequenz-floss.github.io/frequenz-api-common/v'${ver_minor}'/objects.inv|' -i mkdocs.yml
 ```
 
 ### Running tests / checks individually

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev-pylint = [
   "frequenz-api-microgrid[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
 dev-pytest = [
-  "pytest == 7.4.4",
+  "pytest == 8.1.1",
   "frequenz-repo-config[extra-lint-examples] == 0.9.1",
 ]
 dev = [
@@ -124,6 +124,8 @@ disable = [
   # it is a type-check, for which we already have mypy.
   "unsubscriptable-object",
   # Checked by flake8
+  "redefined-outer-name",
+  "unused-import",
   "line-too-long",
   "unused-variable",
   "unnecessary-lambda-assignment",


### PR DESCRIPTION
This repo recently moved to repo-config v0.9. While the dependabot PR for the upgrade passed, the release notes for repo-config suggest more changes. This commit tries to add these additional requirements for repo-config v0.9 upgrade.