### PR TITLE
ci: Use a hash for the labeler version instead of a tag

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,7 +18,7 @@ jobs:
         # only use hashes to pick the action to execute (instead of tags or branches).
         # For more details read:
         # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-        uses: actions/labeler@v5.0.0
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # 5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           dot: true


### PR DESCRIPTION
For security reasons, since we are allowing access to secrets, we should use a hash instead of a tag.