### PR TITLE
Allow clients to specify validity durations for bounds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,11 +17,13 @@
 - The enum `ComponentBoundsTargetMetric` has been removed in favour of the
   `Metric` enum from `frequenz-api-common`.
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- The `AddComponentBoundsRequest` message has a field `validity_duration` which
+  allows the user to specify the duration for which the bounds are valid. The
+  bounds will be automatically removed after the specified duration. The client
+  can select between 5 seconds, 1 minute, 5 minutes, and 15 minutes. If set to
+  `UNSPECIFIED`, the bounds will be valid for a default duration of 5 seconds.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -131,7 +131,11 @@ service Microgrid {
   }
 
   // Adds inclusion bounds for a given metric of a given component. Returns the
-  // time at which the bounds will expire (as a timestamp (UTC))
+  // time at which the bounds will expire (as a timestamp (UTC)).
+  //
+  // The request parameters allows users to select a duration until
+  // which the bounds will stay in effect. If no duration is provided, then the
+  // bounds will be removed after a default duration of 5 seconds.
   //
   // Inclusion bounds give the range that the system will try to keep the
   // metric within. If the metric goes outside of these bounds, the system will
@@ -440,6 +444,15 @@ message ReceiveSensorDataStreamResponse {
   frequenz.api.common.v1.microgrid.sensors.SensorData data = 1;
 }
 
+// The duration for which a given list of bounds will stay in effect.
+enum ComponentBoundsValidityDuration {
+  COMPONENT_BOUNDS_VALIDITY_DURATION_UNSPECIFIED = 0;
+  COMPONENT_BOUNDS_VALIDITY_DURATION_5_SECONDS = 1;
+  COMPONENT_BOUNDS_VALIDITY_DURATION_1_MINUTE = 2;
+  COMPONENT_BOUNDS_VALIDITY_DURATION_5_MINUTES = 3;
+  COMPONENT_BOUNDS_VALIDITY_DURATION_15_MINUTES = 4;
+}
+
 // Request parameters for the RPC `AddComponentBounds`.
 message AddComponentBoundsRequest {
   // The ID of the target component.
@@ -453,6 +466,11 @@ message AddComponentBoundsRequest {
   // pairs of bounds are merged into a single pair of bounds, and
   // non-overlapping ones are kept separated.
   repeated frequenz.api.common.v1.metrics.Bounds bounds = 3;
+
+  // The duration for which the given bounds will stay in effect.
+  // If this field is not provided, then the bounds will be removed after a
+  // default duration of 5 seconds.
+  ComponentBoundsValidityDuration validity_duration = 4;
 }
 
 // Response message for the RPC `AddComponentBounds`.


### PR DESCRIPTION
This commit adds a field named `validity_duration` to the `AddComponentBoundsRequest` message, which can be used by clients to specify a custom default duration to bounds while adding them. If not specified, a default validity duration of 5 seconds is applied.