### PR TITLE
Change the polarity of reactive power

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,11 @@
 - The enum `ComponentBoundsTargetMetric` has been removed in favour of the
   `Metric` enum from `frequenz-api-common`.
 
+- The polarity of reactive power has been changed to follow the IEEE 1459-2010
+  standard definitions. In this standard, positive reactive power is inductive
+  (current is lagging the voltage), and negative reactive power is capacitive
+  (current is leading the voltage).
+
 ## New Features
 
 - The `AddComponentBoundsRequest` message has a field `validity_duration` which

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -197,8 +197,10 @@ service Microgrid {
   // Sets the reactive power output of a component with a given ID, provided the
   // component supports it. The power output is specified in VAr.
   //
-  // The power output can be -ve or +ve, depending on whether the component is
-  // supposed to be delivering inductive or capacitive power, respectively.
+  // We follow the polarity specified in the IEEE 1459-2010 standard
+  // definitions, where
+  //- positive reactive is inductive (current is lagging the voltage)
+  //- negative reactive is capacitive (current is leading the voltage)
   //
   // The return value is the timestamp until which the given power command will
   // stay in effect. After this timestamp, the component's reactive power will
@@ -504,8 +506,11 @@ message SetComponentPowerReactiveRequest {
   uint64 component_id = 1;
 
   // The output reactive power level, in VAr.
-  // -ve values are for inductive (lagging) power , and +ve values are for
-  //  capacitive (leading) power.
+  //
+  // The standard of polarity is as per the IEEE 1459-2010 standard
+  // definitions:
+  // - positive reactive is inductive (current is lagging the voltage)
+  // - negative reactive is capacitive (current is leading the voltage)
   float power = 2;
 }
 


### PR DESCRIPTION
This commit changes the polarity of reactive power in the protobuf definitions to follow the IEEE 1459-2010 standard definitions. In this standard, positive reactive power is inductive (current is lagging the voltage), and negative reactive power is capacitive (current is leading the voltage).