### PR TITLE
Support user-provided lifetimes for set active/reactive power RPCs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,12 @@
   can select between 5 seconds, 1 minute, 5 minutes, and 15 minutes. If set to
   `UNSPECIFIED`, the bounds will be valid for a default duration of 5 seconds.
 
+- The request messages `SetComponentPowerActiveRequest` and
+  `SetComponentPowerReactiveRequest` have a new field named `request_lifetime`
+  which allows the user to specify the duration for which the power setpoints
+  are valid. If this field is not specified in a request, the power setpoint
+  will be valid for 60 seconds.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -489,6 +489,12 @@ message SetComponentPowerActiveRequest {
   // The output active power level, in watts.
   // -ve values are for discharging, and +ve values are for charging.
   float power = 2;
+
+  // The duration, in seconds, until which the request will stay in effect.
+  // This duration has to be between 10 seconds and 15 minutes (including both
+  // limits), otherwise the request will be rejected.
+  // If not provided, it defaults to 60s.
+  optional uint64 request_lifetime = 3;
 }
 
 // Response message for the RPC `SetComponentPowerActive`.
@@ -512,6 +518,12 @@ message SetComponentPowerReactiveRequest {
   // - positive reactive is inductive (current is lagging the voltage)
   // - negative reactive is capacitive (current is leading the voltage)
   float power = 2;
+
+  // The duration, in seconds, until which the request will stay in effect.
+  // This duration has to be between 10 seconds and 15 minutes (including both
+  // limits), otherwise the request will be rejected.
+  // If not provided, it defaults to 60s.
+  optional uint64 request_lifetime = 3;
 }
 
 // Response message for the RPC `SetComponentPowerReactive`.


### PR DESCRIPTION
The request messages `SetComponentPowerActiveRequest` and `SetComponentPowerReactiveRequest` have a new field named `request_lifetime` which allows the user to specify the duration for which the power setpoints are valid. If this field is not specified in a request, the power setpoint will be valid for 60 seconds.

Closes #184.