### PR TITLE
Add CI step to build using `protoc` with fatal warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,32 @@ jobs:
           protolint_version: "0.45.0"
           reporter: github-check
 
+  protoc:
+    name: Test with protoc
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Fetch sources
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Source protoc
+        run: |
+          curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip
+          mkdir protoc
+          unzip protoc-25.1-linux-x86_64.zip -d protoc
+          sudo cp -r protoc/bin/* /usr/bin/
+          sudo cp -r protoc/include/* /usr/include/
+          rm -r protoc-25.1-linux-x86_64.zip protoc
+      - name: Run sanity tests
+        run: |
+          protoc \
+          --fatal_warnings \
+          -I proto \
+          -I submodules/frequenz-api-common/proto \
+          -I submodules/api-common-protos \
+          --python_out=. \
+          frequenz/api/microgrid/v1/microgrid.proto
+
   nox:
     name: Test with nox
     strategy:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,4 +38,6 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- The CI was unable to catch unused imports in the proto file before. This has
+  been fixed by adding a new step to the CI to build using `protoc` with the
+  `--fatal-warnings` flag.


### PR DESCRIPTION
The steps in the CI file from the step `nox` onwards miss a few cases, like reporting unused imports. An additional step with `protoc` takes care of this. This step generates the protoc files directly using `protoc`, and treats warnings as fatal.

Closes #228 