### PR TITLE
Make Dependabot check for updates monthly on Monday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-      time: "07:00"
+      interval: "monthly"
+      day: "monday"
     labels:
       - "part:tooling"
       - "type:tech-debt"


### PR DESCRIPTION
Weekly is just too often.
