### PR TITLE
Upgrade frequenz-api-common from v0.6.0 to v0.6.1 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,9 @@
 
 ## Upgrading
 
-- This release upgrades `frequenz-api-common` to version `v0.6.0`. Please refer
-  to the [release notes](https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.6.0)
+- This release upgrades `frequenz-api-common` to version `v0.6.1`. Please refer
+  to the release notes for [v0.6.0](https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.6.0)
+  and [v0.6.1](https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.6.1)
   of `frequenz-api-common` for more information.
 
 - A new RPC named `AddComponentBounds` has been introduced, which accepts only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.6.0, < 0.7",
+  "frequenz-api-common >= 0.6.1, < 0.7",
   "googleapis-common-protos >= 1.56.4, < 2",
   "grpcio >= 1.51.1, < 2",
 ]


### PR DESCRIPTION
closes #238