### PR TITLE
Pin grpc related dependencies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Frequenz Microgrid API Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix a dependency issue by pinning the `grpcio` version and related libraries.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,44 +2,16 @@
 
 ## Summary
 
-In this release, the Microgrid API has been updated to use the latest version
-of `frequenz-api-common`, in addition a few improvements and a bug fix.
+<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 
-- This release upgrades `frequenz-api-common` to version `v0.6.1`. Please refer
-  to the release notes for [v0.6.0](https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.6.0)
-  and [v0.6.1](https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.6.1)
-  of `frequenz-api-common` for more information.
-
-- A new RPC named `AddComponentBounds` has been introduced, which accepts only
-  inclusive bounds. The old RPCs `AddComponentInclusionBounds` and
-  `AddComponentExclusionBounds` have been removed.
-
-- The enum `ComponentBoundsTargetMetric` has been removed in favour of the
-  `Metric` enum from `frequenz-api-common`.
-
-- The polarity of reactive power has been changed to follow the IEEE 1459-2010
-  standard definitions. In this standard, positive reactive power is inductive
-  (current is lagging the voltage), and negative reactive power is capacitive
-  (current is leading the voltage).
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-- The `AddComponentBoundsRequest` message has a field `validity_duration` which
-  allows the user to specify the duration for which the bounds are valid. The
-  bounds will be automatically removed after the specified duration. The client
-  can select between 5 seconds, 1 minute, 5 minutes, and 15 minutes. If set to
-  `UNSPECIFIED`, the bounds will be valid for a default duration of 5 seconds.
-
-- The request messages `SetComponentPowerActiveRequest` and
-  `SetComponentPowerReactiveRequest` have a new field named `request_lifetime`
-  which allows the user to specify the duration for which the power setpoints
-  are valid. If this field is not specified in a request, the power setpoint
-  will be valid for 60 seconds.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 
-- The CI was unable to catch unused imports in the proto file before. This has
-  been fixed by adding a new step to the CI to build using `protoc` with the
-  `--fatal-warnings` flag.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,6 @@ plugins:
   - mike:
       canonical_version: latest
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-microgrid[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-noxfile = [
-  "nox == 2024.4.15",
-  "frequenz-repo-config[api] == 0.9.1",
-]
+dev-noxfile = ["nox == 2024.4.15", "frequenz-repo-config[api] == 0.9.1"]
 dev-pylint = [
   "pylint == 3.1.0",
   # For checking the noxfile, docs/ script, and tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
   "frequenz-repo-config[api] == 0.9.1",
+  # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
+  # sure the code is generated using the minimum supported versions, as older
+  # versions can't work with code that was generated with newer versions.
+  # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
+  "protobuf == 4.25.3",
+  "grpcio-tools == 1.51.1",
+  "grpcio == 1.51.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -28,7 +35,13 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-common >= 0.6.2, < 0.7",
   "googleapis-common-protos >= 1.56.4, < 2",
-  "grpcio >= 1.51.1, < 2",
+  # We can't widen beyond 6 because of protobuf cross-version runtime guarantees
+  # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
+  "protobuf >= 4.25.3, < 6", # Do not widen beyond 6!
+  # We couldn't find any document with a spec about the cross-version runtime
+  # guarantee for grpcio, so unless we find one in the future, we'll assume
+  # major version jumps are not compatible
+  "grpcio >= 1.51.1, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ dev-mkdocs = [
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.1",
   "mkdocs-material == 9.5.20",
-  "mkdocstrings[python] == 0.23.0",
+  "mkdocstrings[python] == 0.26.1",
+  "mkdocstrings-python == 1.11.1",
   "frequenz-repo-config[api] == 0.9.1",
 ]
 dev-mypy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.6.1, < 0.7",
+  "frequenz-api-common >= 0.6.2, < 0.7",
   "googleapis-common-protos >= 1.56.4, < 2",
   "grpcio >= 1.51.1, < 2",
 ]


### PR DESCRIPTION
We can't use wide dependencies because otherwise when building the wheel, the latest version is used, but the generate code should use the minimum supported version for the generation, not the latest one. See: protobuf.dev/support/cross-version-runtime-guarantee

We also need to update the `frequenz-api-common` dependency to get the fix for the `grpcio` version too.
