### PR TITLE
Bump `protobuf` and `grpcio` dependencies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The minimum supported version of `protobuf` was bumped to 5.28.1 and to 1.66.1 for `grpcio`. Make sure to update your dependencies accordingly.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Frequenz Microgrid API Release Notes
 
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
 ## Bug Fixes
 
-- Fix a dependency issue by pinning the `grpcio` version and related libraries.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ requires = [
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
-  "protobuf == 4.25.3",
-  "grpcio-tools == 1.51.1",
-  "grpcio == 1.51.1",
+  "protobuf == 5.28.1",
+  "grpcio-tools == 1.66.1",
+  "grpcio == 1.66.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -34,14 +34,14 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-common >= 0.6.2, < 0.7",
-  "googleapis-common-protos >= 1.56.4, < 2",
+  "googleapis-common-protos >= 1.65.0, < 2",
   # We can't widen beyond 6 because of protobuf cross-version runtime guarantees
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
-  "protobuf >= 4.25.3, < 6", # Do not widen beyond 6!
+  "protobuf >= 5.28.1, < 7", # Do not widen beyond 7!
   # We couldn't find any document with a spec about the cross-version runtime
   # guarantee for grpcio, so unless we find one in the future, we'll assume
   # major version jumps are not compatible
-  "grpcio >= 1.51.1, < 2", # Do not widen beyond 2!
+  "grpcio >= 1.66.1, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The `protobuf` version 4.25.x will go out of support soon(ish), on 31 Mar 2025. Since we don't need to keep compatibility to any legacy code, we can bump it in advance as a preparation.

The `googleapis-common-protos` version was also bumped to 1.65.0, as the previous version was too old to work with the new `protobuf` version.

https://protobuf.dev/support/version-support/#python
