### PR TITLE
Make `AddComponentBounds` more consistent with other RPCs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 
 - The minimum supported version of `protobuf` was bumped to 5.28.1 and to 1.66.1 for `grpcio`. Make sure to update your dependencies accordingly.
 - The `AddComponentBoundsRequest.validity_duration` field was replaced by `AddComponentBoundsRequest.request_lifetime` to match the fields in `SetComponentPowerActiveRequest` and `SetComponentPowerReactiveRequest`. The default value was also changed from 5 to 60 seconds.
+- The `AddComponentBoundsResponse.ts` field was renamed to `AddComponentBoundsResponse.valid_until` for extra clarity and also to match the fields in `SetComponentPowerActiveResponse` and `SetComponentPowerReactiveResponse`.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ## Upgrading
 
 - The minimum supported version of `protobuf` was bumped to 5.28.1 and to 1.66.1 for `grpcio`. Make sure to update your dependencies accordingly.
+- The `AddComponentBoundsRequest.validity_duration` field was replaced by `AddComponentBoundsRequest.request_lifetime` to match the fields in `SetComponentPowerActiveRequest` and `SetComponentPowerReactiveRequest`. The default value was also changed from 5 to 60 seconds.
 
 ## New Features
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -469,8 +469,11 @@ message AddComponentBoundsRequest {
 
 // Response message for the RPC `AddComponentBounds`.
 message AddComponentBoundsResponse {
-  // The timestamp until which the given bounds will stay in effect.
-  google.protobuf.Timestamp ts = 1;
+  // The timestamp until which the added bounds will stay in effect.
+  // After this timestamp, the component bounds added by this request will be
+  // removed. By default, this timestamp will be set to the current time plus
+  // 60 seconds.
+  google.protobuf.Timestamp valid_until = 1;
 }
 
 // Request parameters for the RPC `SetComponentPowerActive`.

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -446,15 +446,6 @@ message ReceiveSensorDataStreamResponse {
   frequenz.api.common.v1.microgrid.sensors.SensorData data = 1;
 }
 
-// The duration for which a given list of bounds will stay in effect.
-enum ComponentBoundsValidityDuration {
-  COMPONENT_BOUNDS_VALIDITY_DURATION_UNSPECIFIED = 0;
-  COMPONENT_BOUNDS_VALIDITY_DURATION_5_SECONDS = 1;
-  COMPONENT_BOUNDS_VALIDITY_DURATION_1_MINUTE = 2;
-  COMPONENT_BOUNDS_VALIDITY_DURATION_5_MINUTES = 3;
-  COMPONENT_BOUNDS_VALIDITY_DURATION_15_MINUTES = 4;
-}
-
 // Request parameters for the RPC `AddComponentBounds`.
 message AddComponentBoundsRequest {
   // The ID of the target component.
@@ -469,10 +460,11 @@ message AddComponentBoundsRequest {
   // non-overlapping ones are kept separated.
   repeated frequenz.api.common.v1.metrics.Bounds bounds = 3;
 
-  // The duration for which the given bounds will stay in effect.
-  // If this field is not provided, then the bounds will be removed after a
-  // default duration of 5 seconds.
-  ComponentBoundsValidityDuration validity_duration = 4;
+  // The duration, in seconds, until which the request will stay in effect.
+  // This duration has to be between 10 seconds and 15 minutes (including both
+  // limits), otherwise the request will be rejected.
+  // If not provided, it defaults to 60s.
+  optional uint64 request_lifetime = 4;
 }
 
 // Response message for the RPC `AddComponentBounds`.


### PR DESCRIPTION
The `AddComponentBoundsRequest.validity_duration` field was replaced by `AddComponentBoundsRequest.request_lifetime` to match the fields in `SetComponentPowerActiveRequest` and `SetComponentPowerReactiveRequest`. The default value was also changed from 5 to 60 seconds.

The `AddComponentBoundsResponse.ts` field was renamed to `AddComponentBoundsResponse.valid_until` for extra clarity and also to match the fields in `SetComponentPowerActiveResponse` and `SetComponentPowerReactiveResponse`.

Fixes #269.
