### PR TITLE
Bump the protobuf-related dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   protolint:
     name: Check proto files with protolint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Fetch sources
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
     runs-on: ${{ matrix.os }}
@@ -82,7 +82,7 @@ jobs:
 
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
@@ -113,7 +113,7 @@ jobs:
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v3
@@ -152,7 +152,7 @@ jobs:
     name: Publish documentation website to GitHub pages
     needs: ["nox", "build", "protolint"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -238,7 +238,7 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
         uses: actions/download-artifact@v3
@@ -280,7 +280,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-packages
           path: dist/
@@ -142,7 +142,7 @@ jobs:
           mike set-default $MIKE_VERSION
 
       - name: Upload site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist
@@ -287,7 +287,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,6 @@
 
 ## Bug Fixes
 
-- Fix a dependency issue by pinning the `grpcio` version and related libraries.
+- Bump the `protobuf` minimum supported version to 5.26.1, and the maximum version to 7.0.0
+- Bump the `grpcio` and `grpcio-tools` minimum supported versions to 1.63.0
+- Bump the `googleapis-common-protos` minimum supported version to 1.63.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ email = "floss@frequenz.com"
 dev-docstrings = [
   "pydocstyle == 6.3.0",
   "darglint == 1.8.1",
-  "tomli == 2.0.1",      # Needed by pydocstyle to read pyproject.toml
+  "tomli == 2.0.1", # Needed by pydocstyle to read pyproject.toml
 ]
 dev-formatting = ["black == 23.3.0", "isort == 5.12.0"]
 dev-mkdocs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ requires = [
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
-  "protobuf == 4.25.3",
-  "grpcio-tools == 1.51.1",
-  "grpcio == 1.51.1",
+  "protobuf == 5.26.1",
+  "grpcio-tools == 1.63.0",
+  "grpcio == 1.63.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -34,14 +34,14 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-common >= 0.6.2, < 0.7",
-  "googleapis-common-protos >= 1.56.4, < 2",
+  "googleapis-common-protos >= 1.63.1, < 2",
   # We can't widen beyond 6 because of protobuf cross-version runtime guarantees
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
-  "protobuf >= 4.25.3, < 6", # Do not widen beyond 6!
+  "protobuf >= 5.26.1, < 7", # Do not widen beyond 7!
   # We couldn't find any document with a spec about the cross-version runtime
   # guarantee for grpcio, so unless we find one in the future, we'll assume
   # major version jumps are not compatible
-  "grpcio >= 1.51.1, < 2", # Do not widen beyond 2!
+  "grpcio >= 1.63.0, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This is needed to allow for protobuf 6.x, which is already required by other libraries.
