### PR TITLE
Bump Ubuntu version in CI to 24.04 for Test with protoc

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -39,7 +39,7 @@ jobs:
 
   protoc:
     name: Test with protoc
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4


### PR DESCRIPTION
The version 20.04 of Ubuntu is no longer supported.
