### PR TITLE
Bump protobuf-related dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ requires = [
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
-  "protobuf == 5.29.3",
-  "grpcio-tools == 1.70.0",
-  "grpcio == 1.70.0",
+  "protobuf == 6.31.1",
+  "grpcio-tools == 1.72.1",
+  "grpcio == 1.72.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -37,11 +37,11 @@ dependencies = [
   "googleapis-common-protos >= 1.65.0, < 2",
   # We can't widen beyond 6 because of protobuf cross-version runtime guarantees
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
-  "protobuf >= 5.29.3, < 7", # Do not widen beyond 7!
+  "protobuf >= 6.31.1, < 8", # Do not widen beyond 8!
   # We couldn't find any document with a spec about the cross-version runtime
   # guarantee for grpcio, so unless we find one in the future, we'll assume
   # major version jumps are not compatible
-  "grpcio >= 1.70.0, < 2", # Do not widen beyond 2!
+  "grpcio >= 1.72.1, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 
@@ -153,7 +153,15 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-W=all -Werror -Wdefault::DeprecationWarning -Wdefault::PendingDeprecationWarning -vv"
+addopts = "-vv"
+filterwarnings = [
+  "error",
+  "once::DeprecationWarning",
+  "once::PendingDeprecationWarning",
+  # We use a raw string (single quote) to avoid the need to escape special
+  # chars as this is a regex
+  'ignore:Protobuf gencode version .*exactly one major version older.*:UserWarning',
+]
 testpaths = ["pytests"]
 
 [tool.mypy]


### PR DESCRIPTION
Also ignore warnings about protobuf gencode version, as it is guaranteed by protobuf that 2 consecutive major versions are compatible. We are aware that after that we need to update the depencencies, and we'll get an error if we forget anyways.
