### PR TITLE
Bump protobuf-related dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   protolint:
     name: Check proto files with protolint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Fetch sources
@@ -48,7 +48,7 @@ jobs:
 
   protoc:
     name: Test with protoc
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
         python:
           - "3.11"
         nox-session:
@@ -130,7 +130,7 @@ jobs:
 
   build:
     name: Build distribution packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
@@ -162,7 +162,7 @@ jobs:
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch sources
         uses: actions/checkout@v4
@@ -202,7 +202,7 @@ jobs:
     name: Publish documentation website to GitHub pages
     needs: ["nox", "build", "protolint"]
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -289,7 +289,7 @@ jobs:
       # discussions to create the release announcement in the discussion forums
       contents: write
       discussions: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download distribution files
         uses: actions/download-artifact@v4
@@ -331,7 +331,7 @@ jobs:
   publish-to-pypi:
     name: Publish packages to PyPI
     needs: ["create-github-release"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       # For trusted publishing. See:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ requires = [
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
-  "protobuf == 4.25.3",
-  "grpcio-tools == 1.51.1",
-  "grpcio == 1.51.1",
+  "protobuf == 6.31.1",
+  "grpcio-tools == 1.72.1",
+  "grpcio == 1.72.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -33,15 +33,15 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.6.2, < 0.7",
-  "googleapis-common-protos >= 1.56.4, < 2",
+  "frequenz-api-common >= 0.6.5, < 0.7",
+  "googleapis-common-protos >= 1.70.0, < 2",
   # We can't widen beyond 6 because of protobuf cross-version runtime guarantees
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
-  "protobuf >= 4.25.3, < 6", # Do not widen beyond 6!
+  "protobuf >= 6.31.1, < 8", # Do not widen beyond 8!
   # We couldn't find any document with a spec about the cross-version runtime
   # guarantee for grpcio, so unless we find one in the future, we'll assume
   # major version jumps are not compatible
-  "grpcio >= 1.51.1, < 2", # Do not widen beyond 2!
+  "grpcio >= 1.72.1, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 
@@ -53,7 +53,7 @@ email = "floss@frequenz.com"
 dev-flake8 = [
   "flake8 == 7.0.0",
   "flake8-docstrings == 1.7.0",
-  "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
+  "flake8-pyproject == 1.2.3", # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.4.1",
   "pydocstyle == 6.3.0",
 ]
@@ -143,6 +143,15 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
+addopts = "-vv"
+filterwarnings = [
+  "error",
+  "once::DeprecationWarning",
+  "once::PendingDeprecationWarning",
+  # We use a raw string (single quote) to avoid the need to escape special
+  # chars as this is a regex
+  'ignore:Protobuf gencode version .*exactly one major version older.*:UserWarning',
+]
 testpaths = ["pytests"]
 
 [tool.mypy]


### PR DESCRIPTION
Also ignore warnings about protobuf gencode version, as it is guaranteed by protobuf that 2 consecutive major versions are compatible. We are aware that after that we need to update the depencencies, and we'll get an error if we forget anyways.
