### PR TITLE
Rename `GetMicrogridMetadata` RPC to `GetMicrogrid`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,8 @@
   - `ReceiveSensorDataStream` RPC method has been renamed to `ReceiveSensorTelemetryStream` to match the naming conventions used in `frequenz-api-common`.
   - `ReceiveSensorDataStreamRequest` RPC method has been renamed to `ReceiveSensorTelemetryStreamRequest` to match the naming conventions used in `frequenz-api-common`.
   - `ReceiveSensorDataStreamResponse` RPC method has been renamed to `ReceiveSensorTelemetryStreamResponse` to match the naming conventions used in `frequenz-api-common`.
+- The RPC `GetMicrogridMetadata` has been renamed to `GetMicrogrid` to better align with the naming convention in `frequenz-api-common`.
+- The `GetMicrogridMetadataResponse` message has been renamed to `GetMicrogridResponse` to better align with the naming convention in `frequenz-api-common`.
 
 ## New Features
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -24,12 +24,11 @@ import "google/protobuf/timestamp.proto";
 
 // The Frequenz Microgrid API
 service Microgrid {
-  // Returns the microgrid metadata
-  // The metadata consists of information that describes the overall
-  // microgrid, as opposed to its electrical components or sensors,
-  // e.g., the microgrid ID, location.
-  rpc GetMicrogridMetadata(google.protobuf.Empty)
-    returns (GetMicrogridMetadataResponse) {
+  // Returns information about the local microgrid.
+  // This information that describes the overall microgrid, as opposed to its
+  // electrical components or sensors, e.g., the microgrid ID, location.
+  rpc GetMicrogrid(google.protobuf.Empty)
+    returns (GetMicrogridResponse) {
     option (google.api.http) = {
       get : "/v1/metadata"
     };
@@ -323,9 +322,9 @@ service Microgrid {
   }
 }
 
-// Metadata that describes a microgrid.
-message GetMicrogridMetadataResponse {
-  // The location of the microgrid, in geographical co-ordinates.
+// Information describing a microgrid.
+message GetMicrogridResponse {
+  // The information about the local microgrid.
   frequenz.api.common.v1alpha7.microgrid.Microgrid  microgrid= 1;
 }
 


### PR DESCRIPTION
This commit renames the `GetMicrogridMetadata` RPC to `GetMicrogrid`, in order to align with the naming conventions used in `frequenz-api-common`. The response payload message `GetMicrogridMetadataResponse` is also renamed to `GetMicrogridResponse` to match the new RPC name.