### PR TITLE
Add `ramp_rate` to SetComponentPowerActive/ReactiveRequest

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@
   - `ReceiveSensorDataStreamResponse` RPC method has been renamed to `ReceiveSensorTelemetryStreamResponse` to match the naming conventions used in `frequenz-api-common`.
 - The RPC `GetMicrogridMetadata` has been renamed to `GetMicrogrid` to better align with the naming convention in `frequenz-api-common`.
 - The `GetMicrogridMetadataResponse` message has been renamed to `GetMicrogridResponse` to better align with the naming convention in `frequenz-api-common`.
+- Add `ramp_rate` to `SetElectricalComponentPowerActiveRequest` and `SetElectricalComponentPowerReactiveRequest` messages to allow setting the desired ramp rate for active and reactive power changes.
 
 ## New Features
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -450,7 +450,6 @@ message ReceiveSensorTelemetryStreamResponse {
   // The sensor data.
   frequenz.api.common.v1alpha7.microgrid.sensors.SensorTelemetry telemetry = 1;
 }
-
 // Request parameters for the RPC `AddElectricalComponentBounds`.
 message AddElectricalComponentBoundsRequest {
   // The ID of the target electrical component.
@@ -495,6 +494,27 @@ message SetElectricalComponentPowerActiveRequest {
   // limits), otherwise the request will be rejected.
   // If not provided, it defaults to 60s.
   optional uint64 request_lifetime = 3;
+
+  // The desired rate of change for the power output, in watts per second.
+  // This is useful in scenarios where the rate of change of the power output
+  // of the electrical component is critical to the use-case of the client.
+  //
+  // This value represents the magnitude of the ramp and must always be a
+  // positive integer. The service automatically applies it in the correct
+  // direction (ramping up or down) to reach the target `power`.
+  //
+  // This rate is capped to the component's own configured maximum ramp rate.
+  // The actual rate of change will be the lesser of the requested rate and the
+  // component's limit.
+  //
+  // Edge-cases and precedence:
+  // - The ramping is applied only if the component supports it.
+  // - If `request_lifetime` ends before the ramp is complete, the ramp is
+  //   halted, and the component is set to its standby state.
+  // - If a new command arrives mid-ramp, the current ramp is interrupted and
+  //   a new one begins according to the new command's parameters.
+  // - If not provided, the component uses its configured maximum ramp rate.
+  optional uint32 ramp_rate = 4;
 }
 
 // Response message for the RPC `SetElectricalComponentPowerActive`.
@@ -524,6 +544,26 @@ message SetElectricalComponentPowerReactiveRequest {
   // limits), otherwise the request will be rejected.
   // If not provided, it defaults to 60s.
   optional uint64 request_lifetime = 3;
+
+  // The desired rate of change for the power output, in volt-amperes per
+  // second.
+  //
+  // This value represents the magnitude of the ramp and must always be a
+  // positive integer. The service automatically applies it in the correct
+  // direction (ramping up or down) to reach the target `power`.
+  //
+  // This rate is capped to the component's own configured maximum ramp rate.
+  // The actual rate of change will be the lesser of the requested rate and the
+  // component's limit.
+  //
+  // Edge-cases and precedence:
+  // - The ramping is applied only if the component supports it.
+  // - If `request_lifetime` ends before the ramp is complete, the ramp is
+  //   halted, and the component is set to its standby state.
+  // - If a new command arrives mid-ramp, the current ramp is interrupted and
+  //   a new one begins according to the new command's parameters.
+  // - If not provided, the component uses its configured maximum ramp rate.
+  optional uint32 ramp_rate = 4;
 }
 
 // Response message for the RPC `SetElectricalComponentPowerReactive`.


### PR DESCRIPTION
This commit adds a `ramp_rate` field to the
`SetComponentPowerActiveRequest` and `SetComponentPowerReactiveRequest` messages. This field allows users to specify the desired rate of change for the power output of electrical components in a microgrid. This is useful in scenarios where the rate of change of power is critical tio the use-case of the client.

The `ramp_rate` field is an optional unsigned integer that represents the magnitude of the ramp in watts per second (for active power) or volt-amperes per second (for reactive power). The service will apply the ramp in the correct direction (up or down) to reach the target power. The actual rate of change will be capped by the component's configured maximum ramp rate, ensuring that the system operates within the component's limits.

If the `request_lifetime` ends before the ramp is complete, the component will be set to its standby state. If a new command arrives mid-ramp, the current ramp will be interrupted, and a new one will begin according to the new command's parameters. If the `ramp_rate` is not provided, the component will use its configured maximum ramp rate.

closes #287 