### PR TITLE
Stream responses for `SetElectricalComponentPowerActive/Reactive` RPCs 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,8 @@
   - `ReceiveSensorDataStreamResponse` RPC method has been renamed to `ReceiveSensorTelemetryStreamResponse` to match the naming conventions used in `frequenz-api-common`.
 - The RPC `GetMicrogridMetadata` has been renamed to `GetMicrogrid` to better align with the naming convention in `frequenz-api-common`.
 - The `GetMicrogridMetadataResponse` message has been renamed to `GetMicrogridResponse` to better align with the naming convention in `frequenz-api-common`.
+- The response messages for the `SetElectricalComponentPowerActive` and
+`SetElectricalComponentPowerReactive` RPCs have been changed to return a stream of responses instead of a single response. This allows the server to provide ongoing status updates for the request, which is useful when the electrical component cannot immediately set its output power to the requested value.
 
 ## New Features
 

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -169,11 +169,19 @@ service Microgrid {
   // The power output can be -ve or +ve, depending on whether the electrical
   // component is supposed to be discharging or charging, respectively.
   //
-  // The return value is the timestamp until which the given power command will
-  // stay in effect. After this timestamp, the electrical component's active
-  // power will be set to 0, if the API receives no further command to change
-  // it before then. By default, this timestamp will be set to the current time
-  // plus 60 seconds.
+  // The server provides a stream of responses in return. Each response will
+  // contain the current status of the request.
+  // **Initial response:** The initial response will be sent immediately after
+  // the request is received, and will indicate whether the request was accepted
+  // or rejected. If the request was accepted, this response will also contain
+  // the timestamp until which the given power command will stay in effect,
+  // after which the electrical component will be returned to its default state.
+  // **Subsequent response:** After the initial response, the server will send
+  // another response in the stream, which will be the final response. It will
+  // indicate whether the request was successful, failed, or overridden by
+  // another request. If the request was successful, it will also contain the
+  // timestamp until which the given power command will stay in effect, after
+  // which the electrical component will be returned to its default state.
   //
   // Note that the target electrical component may have a resolution of more
   // than 1 W. E.g., an inverter may have a resolution of 88 W.
@@ -186,7 +194,7 @@ service Microgrid {
   // * Inverter: Sends the discharge command to the inverter, making it deliver
   //  AC power.
   rpc SetElectricalComponentPowerActive(SetElectricalComponentPowerActiveRequest)
-    returns (SetElectricalComponentPowerActiveResponse) {
+    returns (stream SetElectricalComponentPowerActiveResponse) {
     option (google.api.http) = {
       get : "/v1/components/{electrical_component_id}/setPowerActive/{power}"
     };
@@ -201,11 +209,19 @@ service Microgrid {
   //- positive reactive is inductive (current is lagging the voltage)
   //- negative reactive is capacitive (current is leading the voltage)
   //
-  // The return value is the timestamp until which the given power command will
-  // stay in effect. After this timestamp, the electrical component's reactive
-  // power will be set to 0, if the API receives no further command to change it
-  // before then.
-  // By default, this timestamp will be set to the current time plus 60 seconds.
+  // The server provides a stream of responses in return. Each response will
+  // contain the current status of the request.
+  // **Initial response:** The initial response will be sent immediately after
+  // the request is received, and will indicate whether the request was accepted
+  // or rejected. If the request was accepted, this response will also contain
+  // the timestamp until which the given power command will stay in effect,
+  // after which the electrical component will be returned to its default state.
+  // **Subsequent response:** After the initial response, the server will send
+  // another response in the stream, which will be the final response. It will
+  // indicate whether the request was successful, failed, or overridden by
+  // another request. If the request was successful, it will also contain the
+  // timestamp until which the given power command will stay in effect, after
+  // which the electrical component will be returned to its default state.
   //
   // Note that the target electrical component may have a resolution of more
   // than 1 VAr.
@@ -213,7 +229,7 @@ service Microgrid {
   // In such cases, the magnitude of power will be floored to the nearest
   // multiple of the resolution.
   rpc SetElectricalComponentPowerReactive(SetElectricalComponentPowerReactiveRequest)
-    returns (SetElectricalComponentPowerReactiveResponse) {
+    returns (stream SetElectricalComponentPowerReactiveResponse) {
     option (google.api.http) = {
       get : "/v1/components/{electrical_component_id}/setPowerReactive/{power}"
     };
@@ -497,13 +513,78 @@ message SetElectricalComponentPowerActiveRequest {
   optional uint64 request_lifetime = 3;
 }
 
+// Response codes for the `SetElectricalComponentPowerActive` and
+// `SetElectricalComponentPowerReactive` RPCs. These codes indicate the ongoing
+// status of the request to set the power of an electrical component.
+//
+// Often, electrical components are not able to immediately set their output
+// power to the requested value. This can happen due to several reasons,
+// including, but not limited to:
+// - having to ramp up or down the power output from the current output.
+// - having to wait for the electrical component to reach a stable state before
+//   applying the new power set-point.
+// - communication latency between the API service and the electrical
+//   component.
+//
+// In such cases, an initial response is sent to the client, indicating that the
+// request has been accepted, and it is followed by a stream of responses
+// indicating the ongoing status of the request.
+enum SetElectricalComponentPowerRequestStatus {
+  // Default value. Users are discouraged from using this value.
+  SET_ELECTRICAL_COMPONENT_POWER_REQUEST_STATUS_UNSPECIFIED = 0;
+
+  // The request has been accepted, and the target power set-point will be
+  // applied to the electrical component.
+  //
+  // Once the API service has received a request to set the power of an
+  // electrical component, it will validate the input parameters immediately.
+  // If the parameters are valid, the service will return this code
+  // immediately, and then proceed to apply the power set-point to the
+  // electrical component.
+  SET_ELECTRICAL_COMPONENT_POWER_REQUEST_STATUS_ACCEPTED = 1;
+
+  // The request has been rejected because of invalid input parameters.
+  //
+  // Once the API service has received a request to set the power of an
+  // electrical component, it will validate the input parameters immediately.
+  // If the parameters are invalid, the service will return this code
+  // immediately, and will not apply the power set-point to the
+  // electrical component.
+  SET_ELECTRICAL_COMPONENT_POWER_REQUEST_STATUS_REJECTED = 2;
+
+  // The request has failed midway, and the electrical component is not
+  // at the desired power level.
+  //
+  // This code indicates that the request to set the power of an electrical
+  // component has been accepted, but the service encountered an error while
+  // applying the power set-point to the electrical component.
+  SET_ELECTRICAL_COMPONENT_POWER_REQUEST_STATUS_FAILED = 3;
+
+  // The request has been successfully processed.
+  SET_ELECTRICAL_COMPONENT_POWER_REQUEST_STATUS_SUCCESS = 4;
+
+  // The request has been overridden by another request.
+  //
+  // This could happen if a new request to set the power of an electrical
+  // component arrives while the previous request is still being processed.
+  SET_ELECTRICAL_COMPONENT_POWER_REQUEST_STATUS_OVERRIDDEN = 5;
+}
+
 // Response message for the RPC `SetElectricalComponentPowerActive`.
 message SetElectricalComponentPowerActiveResponse {
   // The timestamp until which the given power command will stay in effect.
-  // After this timestamp, the electrical component power will be set to 0, if
-  // the API receives no further power commands. By default, this timestamp will
-  // be set to the current time plus 60 seconds.
-  google.protobuf.Timestamp valid_until = 1;
+  // After this timestamp, the electrical component power will be set to its
+  // standby state, if the API receives no further power commands.
+  // By default, this timestamp will be set to the current time plus 60 seconds.
+  //
+  // When the request status is `REJECTED`, `FAILED`, or `OVERRIDDEN`, the
+  // `valid_until` timestamp will not be set, and the electrical component
+  // will not change its power output.
+  optional google.protobuf.Timestamp valid_until = 1;
+
+  // The current status of the request to set the power of the electrical
+  // component.
+  SetElectricalComponentPowerRequestStatus status = 2;
 }
 
 // Request parameters for the RPC `SetElectricalComponentPowerReactive`.
@@ -529,10 +610,18 @@ message SetElectricalComponentPowerReactiveRequest {
 // Response message for the RPC `SetElectricalComponentPowerReactive`.
 message SetElectricalComponentPowerReactiveResponse {
   // The timestamp until which the given power command will stay in effect.
-  // After this timestamp, the electrical component power will be set to 0, if
-  // the API receives no further power commands. By default, this timestamp will
-  // be set to the current time plus 60 seconds.
-  google.protobuf.Timestamp valid_until = 1;
+  // After this timestamp, the electrical component power will be set to its
+  // standby state, if the API receives no further power commands.
+  // By default, this timestamp will be set to the current time plus 60 seconds.
+  //
+  // When the request status is `REJECTED`, `FAILED`, or `OVERRIDDEN`, the
+  // `valid_until` timestamp will not be set, and the electrical component
+  // will not change its power output.
+  optional google.protobuf.Timestamp valid_until = 1;
+
+  // The current status of the request to set the power of the electrical
+  // component.
+  SetElectricalComponentPowerRequestStatus status = 2;
 }
 
 // Request parameters for the RPC `StartElectricalComponent`.


### PR DESCRIPTION
The response messages for the `SetElectricalComponentPowerActive` and `SetElectricalComponentPowerReactive` RPCs have been changed to return a stream of responses instead of a single response. This allows the server to provide ongoing status updates for the request, which is useful when the electrical component cannot immediately set its output power to the requested value. The initial response will indicate whether the request was accepted or rejected, and a subsequent response will indicate whether the request was successful, failed, or overridden by another request. If the request was accepted and successful, the response will also contain the timestamp until which the given power command will stay in effect, after which the electrical component will be returned to its default state.
