### PR TITLE
Rename fields in `ListElectricalComponentConnectionsRequest`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,8 @@
   - `ReceiveSensorDataStream` RPC method has been renamed to `ReceiveSensorTelemetryStream` to match the naming conventions used in `frequenz-api-common`.
   - `ReceiveSensorDataStreamRequest` RPC method has been renamed to `ReceiveSensorTelemetryStreamRequest` to match the naming conventions used in `frequenz-api-common`.
   - `ReceiveSensorDataStreamResponse` RPC method has been renamed to `ReceiveSensorTelemetryStreamResponse` to match the naming conventions used in `frequenz-api-common`.
+  - `ListComponentConnectionRequests.starts` has been renamed to `ListElectricalComponentConnectionRequests.source_component_ids` to match the naming conventions used in `frequenz-api-common`.
+  - `ListComponentConnectionRequests.ends` has been renamed to `ListElectricalComponentConnectionRequests.destination_component_ids` to match the naming conventions used in `frequenz-api-common`.
 - The RPC `GetMicrogridMetadata` has been renamed to `GetMicrogrid` to better align with the naming convention in `frequenz-api-common`.
 - The `GetMicrogridMetadataResponse` message has been renamed to `GetMicrogridResponse` to better align with the naming convention in `frequenz-api-common`.
 - The response messages for the `SetElectricalComponentPowerActive` and

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -383,13 +383,15 @@ message ListSensorsResponse {
 message ListElectricalComponentConnectionsRequest {
   // Only return connections that start from the specified electrical
   // component ID(s).
-  // If empty, connections with any `start` will be returned.
-  repeated uint64 starts = 1;
+  // If this list is empty, connections with any `source_component_id` will be
+  // returned.
+  repeated uint64 source_component_ids = 1;
 
-  // Only return connections that end at the specified electrical
-  // component ID(s).
-  // if empty, connections with any `end` will be returned.
-  repeated uint64 ends = 2;
+  // Only return connections that end at the specified electrical component
+  // ID(s).
+  // If this list is empty, connections with any `destination_component_id`
+  // will be returned.
+  repeated uint64 destination_component_ids = 2;
 }
 
 // Response message for the RPC `ListElectricalComponentConnections`.


### PR DESCRIPTION
This commit renames the fields in the
`ListElectricalComponentConnectionsRequest` message:
- `starts` is renamed to `source_component_ids`
- `ends` is renamed to `destination_component_ids`

This change improves clarity by explicitly indicating that the fields represent the source and destination electrical component IDs in the connections request.

This change also aligns it with the naming convention of electrical component connections in the `frequenz-api-common` repository.