### PR TITLE
Revert validity_duration of `AddComponentBoundsRequest` to 5 seconds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@
 ## Upgrading
 
 - The minimum supported version of `protobuf` was bumped to 5.28.1 and to 1.66.1 for `grpcio`. Make sure to update your dependencies accordingly.
-- The `AddComponentBoundsRequest.validity_duration` field was replaced by `AddComponentBoundsRequest.request_lifetime` to match the fields in `SetComponentPowerActiveRequest` and `SetComponentPowerReactiveRequest`. The default value was also changed from 5 to 60 seconds.
+- The `AddComponentBoundsRequest.validity_duration` field was replaced by `AddComponentBoundsRequest.request_lifetime` to match the fields in `SetComponentPowerActiveRequest` and `SetComponentPowerReactiveRequest`.
 - The `AddComponentBoundsResponse.ts` field was renamed to `AddComponentBoundsResponse.valid_until` for extra clarity and also to match the fields in `SetComponentPowerActiveResponse` and `SetComponentPowerReactiveResponse`.
 - The version of `frequenz-api-common` has been updated to v0.7.0. Please refer to the [release notes](https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.7.0) and update your code accordingly.
   - Sensor categories have been removed from `frequenz-api-common`, and are therefore removed from the Microgrid API as well.

--- a/proto/frequenz/api/microgrid/v1/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1/microgrid.proto
@@ -469,9 +469,9 @@ message AugmentElectricalComponentBoundsRequest {
   repeated frequenz.api.common.v1alpha7.metrics.Bounds bounds = 3;
 
   // The duration, in seconds, until which the request will stay in effect.
-  // This duration has to be between 10 seconds and 15 minutes (including both
+  // This duration has to be between 5 seconds and 15 minutes (including both
   // limits), otherwise the request will be rejected.
-  // If not provided, it defaults to 60s.
+  // If not provided, it defaults to 5s.
   optional uint64 request_lifetime = 4;
 }
 


### PR DESCRIPTION
The previous validity duration of 60 seconds was too long for the microgrid use case, where a shorter duration of 5 seconds is more appropriate. This is because these bounds restraint the capabilities the electrical components, and the way for clients to revert their bounds is to stop sending bounds. This is the desired approach, since it keeps the overhead on the client side low. Given this style of intteraction, the older 5s default is more appropriate, since it allows clients to quickly revert their bounds without having to wait for a long time.