### PR TITLE
Add `bounds_token` and `ClearElectricalComponentBounds` RPC to v1alpha18/19

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,42 +2,16 @@
 
 ## Summary
 
-This release introduces a new preview API version, `v1alpha19`, alongside the stable `v1` API.
+<!-- Here goes a general summary of what this release is about -->
 
-The `v1` API remains unchanged to ensure backward compatibility. All new features are available exclusively in the new `v1alpha19` package.
+## Upgrading
 
------
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
-## Stable `v1` and `v1alpha18` APIs
+## New Features
 
-The `v1` and `v1alpha18` APIs are stable and have **not** been changed in this release. Users currently on these API versions do not need to make any changes, beyond potentially updating python dependencies.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
------
+## Bug Fixes
 
-## New `v1alpha19` Preview API
-
-A new package, `frequenz.api.microgrid.v1alpha19`, has been introduced to provide access to the latest features. The `v1alpha19` API introduces a more streamlined and robust interface compared to the stable `v1` API.
-
------
-
-## Upgrading to the `v0.19.0` release
-
-### 1. Dependency Updates
-
-Despite the `v1` API remaining unchanged, your project's dependencies may need to be updated, due to the following python dependency updates:
-
------
-
-## Upgrading to the `v1alpha19` API
-
-Alongside upgrading to the `v0.19.0` release, you can also upgrade to the new `v1alpha19` API, which includes several significant changes and improvements.
-
------
-
-### 1. Symbol Renaming
-
-Numerous symbols were renamed. The changes are primarily for clarity and consistency with the new `frequenz-api-common` API. The changes are listed below:
-
-| Type    | Old Name                                                                          | New Name                                                                                    |
-| :------ | :-------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------ |
-| Message | `ReceiveElectricalComponentTelemetryStreamRequest.ComponentTelemetryStreamFilter` | `ReceiveElectricalComponentTelemetryStreamRequest.ElectricalComponentTelemetryStreamFilter` |
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 **In both v1alpha18 and v1alpha19:**
 
 - A new field named `bounds_token` has been added to the `AugmentElectricalComponentBoundsRequest` message. This field allows clients to specify a token that identifies their bounds contribution. If a client wants to overwrite a previously set bounds contribution, they can use the same token in a new request.
+- A new RPC named `ClearElectricalComponentBounds` has been introduced. This RPC allows clients to withdraw a previously set bounds contribution by specifying the component, metric, and the token associated with that contribution.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,9 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+**In both v1alpha18 and v1alpha19:**
+
+- A new field named `bounds_token` has been added to the `AugmentElectricalComponentBoundsRequest` message. This field allows clients to specify a token that identifies their bounds contribution. If a client wants to overwrite a previously set bounds contribution, they can use the same token in a new request.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/microgrid/v1alpha18/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1alpha18/microgrid.proto
@@ -136,6 +136,12 @@ service Microgrid {
   // which the bounds will stay in effect. If no duration is provided, then the
   // bounds will be removed after a default duration of 5 seconds.
   //
+  // The RPC offers two ways to retire bounds, both via its request body:
+  // - by providing a `request_lifetime` duration, after which the bounds will
+  //   be automatically removed, or
+  // - by providing a `bounds_token`, which can be re-used in a subsequent
+  //   request to immediately overwrite the bounds added by an older request.
+  //
   // Inclusion bounds give the range that the system will try to keep the
   // metric within. If the metric goes outside of these bounds, the system will
   // try to bring it back within the bounds.
@@ -472,7 +478,30 @@ message AugmentElectricalComponentBoundsRequest {
   // This duration has to be between 5 seconds and 15 minutes (including both
   // limits), otherwise the request will be rejected.
   // If not provided, it defaults to 5s.
+  //
+  // Note that the bounds may also expire before this duration, if the client
+  // provides the same `bounds_token` in a subsequent request for the same
+  // electrical component and metric.
   optional uint64 request_lifetime = 4;
+
+  // A client-generated token, used to track the bounds added by this request.
+  //
+  // It can be re-used in a subsequent request for the same electrical component
+  // and metric to immediately overwrite the bounds added by this request, and
+  // remove them from the overall bounds for the given metric.
+  //
+  // The service should allow the same token to be used for different electrical
+  // component IDs and metrics. This means that clients can expect that using
+  // the same token in a subsequent request for a different electrical component
+  // or metric will _not_ overwrite the bounds added by this request.
+  //
+  // If there is no bound contribution currently active for the given token,
+  // electrical component ID, and metric, then the request will be treated as a
+  // new one.
+  //
+  // Clients are strongly recommended to incorporate randomness in the token to
+  // avoid collisions, e.g. by using a random 64-bit value.
+  optional string bounds_token = 5;
 }
 
 // Response message for the RPC `AugmentElectricalComponentBounds`.
@@ -481,6 +510,11 @@ message AugmentElectricalComponentBoundsResponse {
   // After this timestamp, the electrical component bounds added by this request
   // will be removed. By default, this timestamp will be set to the current
   // time plus 60 seconds.
+  //
+  // Note that if the client provides the same `bounds_token` in a subsequent
+  // request for the same electrical component and metric, then the bounds added
+  // by this request will be removed immediately, and the `valid_until_time`
+  // timestamp will not be relevant anymore.
   google.protobuf.Timestamp valid_until_time = 1;
 }
 

--- a/proto/frequenz/api/microgrid/v1alpha18/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1alpha18/microgrid.proto
@@ -171,6 +171,18 @@ service Microgrid {
   rpc AugmentElectricalComponentBounds(AugmentElectricalComponentBoundsRequest)
     returns (AugmentElectricalComponentBoundsResponse);
 
+  // This RPC allows clients to remove bounds that were previously added using
+  // the `AugmentElectricalComponentBounds` RPC. Clients can specify the
+  // electrical component ID, metric, and token to identify the bounds to be
+  // cleared.
+  //
+  // If the specified bounds exist, they will be removed from the overall bounds
+  // for the given metric of the electrical component.
+  // If the specified bounds do not exist, the request will be treated as a
+  // no-op.
+  rpc ClearElectricalComponentBounds(ClearElectricalComponentBoundsRequest)
+    returns (google.protobuf.Empty);
+
   // Sets the active or reactive power output of a electrical component to a
   // specified target.
   // This RPC allows setting either active or reactive power in a single
@@ -516,6 +528,19 @@ message AugmentElectricalComponentBoundsResponse {
   // by this request will be removed immediately, and the `valid_until_time`
   // timestamp will not be relevant anymore.
   google.protobuf.Timestamp valid_until_time = 1;
+}
+
+// Request parameters for the RPC `ClearElectricalComponentBounds`.
+message ClearElectricalComponentBoundsRequest {
+  // The ID of the target electrical component.
+  uint64 electrical_component_id = 1;
+
+  // The target metric whose bounds have to be cleared.
+  frequenz.api.common.v1alpha8.metrics.Metric target_metric = 2;
+
+  // A client-generated token, used to track the bounds added by a previous
+  // request.
+  string bounds_token = 3;
 }
 
 // The type of power requested for an electrical component.

--- a/proto/frequenz/api/microgrid/v1alpha19/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1alpha19/microgrid.proto
@@ -136,6 +136,12 @@ service Microgrid {
   // which the bounds will stay in effect. If no duration is provided, then the
   // bounds will be removed after a default duration of 5 seconds.
   //
+  // The RPC offers two ways to retire bounds, both via its request body:
+  // - by providing a `request_lifetime` duration, after which the bounds will
+  //   be automatically removed, or
+  // - by providing a `bounds_token`, which can be re-used in a subsequent
+  //   request to immediately overwrite the bounds added by an older request.
+  //
   // Inclusion bounds give the range that the system will try to keep the
   // metric within. If the metric goes outside of these bounds, the system will
   // try to bring it back within the bounds.
@@ -472,7 +478,30 @@ message AugmentElectricalComponentBoundsRequest {
   // This duration has to be between 5 seconds and 15 minutes (including both
   // limits), otherwise the request will be rejected.
   // If not provided, it defaults to 5s.
+  //
+  // Note that the bounds may also expire before this duration, if the client
+  // provides the same `bounds_token` in a subsequent request for the same
+  // electrical component and metric.
   optional uint64 request_lifetime = 4;
+
+  // A client-generated token, used to track the bounds added by this request.
+  //
+  // It can be re-used in a subsequent request for the same electrical component
+  // and metric to immediately overwrite the bounds added by this request, and
+  // remove them from the overall bounds for the given metric.
+  //
+  // The service should allow the same token to be used for different electrical
+  // component IDs and metrics. This means that clients can expect that using
+  // the same token in a subsequent request for a different electrical component
+  // or metric will _not_ overwrite the bounds added by this request.
+  //
+  // If there is no bound contribution currently active for the given token,
+  // electrical component ID, and metric, then the request will be treated as a
+  // new one.
+  //
+  // Clients are strongly recommended to incorporate randomness in the token to
+  // avoid collisions, e.g. by using a random 64-bit value.
+  optional string bounds_token = 5;
 }
 
 // Response message for the RPC `AugmentElectricalComponentBounds`.
@@ -481,6 +510,11 @@ message AugmentElectricalComponentBoundsResponse {
   // After this timestamp, the electrical component bounds added by this request
   // will be removed. By default, this timestamp will be set to the current
   // time plus 60 seconds.
+  //
+  // Note that if the client provides the same `bounds_token` in a subsequent
+  // request for the same electrical component and metric, then the bounds added
+  // by this request will be removed immediately, and the `valid_until_time`
+  // timestamp will not be relevant anymore.
   google.protobuf.Timestamp valid_until_time = 1;
 }
 

--- a/proto/frequenz/api/microgrid/v1alpha19/microgrid.proto
+++ b/proto/frequenz/api/microgrid/v1alpha19/microgrid.proto
@@ -171,6 +171,18 @@ service Microgrid {
   rpc AugmentElectricalComponentBounds(AugmentElectricalComponentBoundsRequest)
     returns (AugmentElectricalComponentBoundsResponse);
 
+  // This RPC allows clients to remove bounds that were previously added using
+  // the `AugmentElectricalComponentBounds` RPC. Clients can specify the
+  // electrical component ID, metric, and token to identify the bounds to be
+  // cleared.
+  //
+  // If the specified bounds exist, they will be removed from the overall bounds
+  // for the given metric of the electrical component.
+  // If the specified bounds do not exist, the request will be treated as a
+  // no-op.
+  rpc ClearElectricalComponentBounds(ClearElectricalComponentBoundsRequest)
+    returns (google.protobuf.Empty);
+
   // Sets the active or reactive power output of a electrical component to a
   // specified target.
   // This RPC allows setting either active or reactive power in a single
@@ -516,6 +528,19 @@ message AugmentElectricalComponentBoundsResponse {
   // by this request will be removed immediately, and the `valid_until_time`
   // timestamp will not be relevant anymore.
   google.protobuf.Timestamp valid_until_time = 1;
+}
+
+// Request parameters for the RPC `ClearElectricalComponentBounds`.
+message ClearElectricalComponentBoundsRequest {
+  // The ID of the target electrical component.
+  uint64 electrical_component_id = 1;
+
+  // The target metric whose bounds have to be cleared.
+  frequenz.api.common.v1alpha8.metrics.Metric target_metric = 2;
+
+  // A client-generated token, used to track the bounds added by a previous
+  // request.
+  string bounds_token = 3;
 }
 
 // The type of power requested for an electrical component.


### PR DESCRIPTION
This PR adds a token-based mechanism for retiring electrical component bounds contributions early, applied identically to both the `v1alpha18` and `v1alpha19` proto packages.

Previously, bounds added via `AugmentElectricalComponentBounds` could only expire passively via `request_lifetime`.

The commit sequence here first introduces the `bounds_token` field on `AugmentElectricalComponentBoundsRequest`, letting a client tag its bounds contribution and later overwrite it by reusing the same token. It then adds a new `ClearElectricalComponentBounds` RPC that lets a client withdraw a tagged contribution outright, given the component, metric, and token.

## Non-Breaking Changes:
- **Add `bounds_token` field to `AugmentElectricalComponentBoundsRequest`**: Adds a new optional `bounds_token` field so clients can tag a bounds contribution and later overwrite it by reusing the token in a subsequent request, instead of waiting for `request_lifetime` to expire.
- **Add RPC to clear previously set bounds**: Introduces `ClearElectricalComponentBounds`, allowing a client to withdraw a bounds contribution (identified by component, metric, and `bounds_token`) before its lifetime elapses; missing/already-expired contributions are treated as a no-op.

## Dropped Alternative

We could have done this with with server-side-tokens too, but it has one drawback -  it risks clients losing in-flight responses. That is an inherently server-side token problem, and has an eventual consequence that defeats its purpose - if an in-flight response gets missed, then those bounds-contribution can never be overwritten or revoked. If the lifetime of such an outdated bounds-contribution is 15-minutes, then its effect lingers for long enough to affect microgrid performance.

The client-side-token approach resolves that problem. The only downside is that the client has to manage its own token. It also offers a potentially more powerful interface to manage its bounds, since clients can now track their bounds-contributions themselves.

closes #441 