### PR TITLE
Reset the release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,16 @@
 
 ## Summary
 
-This release adds a new RPC to clear previously set bounds contributions for electrical components, and introduces a new field to the `AugmentElectricalComponentBoundsRequest` message to allow clients to specify a token for their bounds contribution.
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-**In v1alpha18:**
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
-- A new field named `bounds_token` has been added to the `AugmentElectricalComponentBoundsRequest` message. This field allows clients to specify a token that identifies their bounds contribution. If a client wants to overwrite a previously set bounds contribution, they can use the same token in a new request.
-- A new RPC named `ClearElectricalComponentBounds` has been introduced. This RPC allows clients to withdraw a previously set bounds contribution by specifying the component, metric, and the token associated with that contribution.
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->


### PR DESCRIPTION
v0.18.2 has been released from this branch. Reset RELEASE_NOTES.md to the template as described in CONTRIBUTING.md's release process.